### PR TITLE
Allow running CPU and GPU tests separately

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,4 +22,6 @@ Input data for methods
 
 Run tests
 =========
-* Run tests with :code:`$ pytest`. To increase verbosity, use :code:`$ pytest -v`.
+* Run all tests with :code:`$ pytest`. To increase verbosity, use :code:`$ pytest -v`.
+* Run GPU tests separately with :code:`$ pytest -v -m gpu`.
+* Run CPU tests separately with :code:`$ pytest -v -m "not gpu"`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,6 @@ testpaths = [
 ]
 filterwarnings = [
     "ignore::DeprecationWarning",
+    "ignore::pytest.PytestUnknownMarkWarning",
     "ignore::scipy.stats.ConstantInputWarning",
 ]

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -12,6 +12,7 @@ from tomopy.prep.stripe import remove_stripe_based_sorting
 from tomopy.recon.rotation import find_center_vo
 
 
+@cp.testing.gpu
 def test_cpu_vs_gpu():
     #--- GPU pipeline tested on `tomo_standard` ---#
 

--- a/tests/test_prep/test_alignment.py
+++ b/tests/test_prep/test_alignment.py
@@ -8,6 +8,7 @@ from httomolib.prep.alignment import (
 )
 
 
+@cp.testing.gpu
 def test_correct_distortion():
     distortion_coeffs_path = \
         'tests/test_data/distortion-correction/distortion-coeffs.txt'

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -6,6 +6,7 @@ from cupy.testing import assert_allclose
 from httomolib.prep.normalize import normalize_cupy, normalize_raw_cuda
 
 
+@cp.testing.gpu
 def test_normalize():
     # testing cupy implementation for normalization
 

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -13,6 +13,7 @@ data = cp.array(host_data)
 eps = 1e-6
 
 
+@cp.testing.gpu
 def test_fresnel_filter():
     # --- testing the Fresnel filter on tomo_standard ---#
     pattern = 'PROJECTION'
@@ -39,6 +40,7 @@ def test_fresnel_filter():
     cp._default_memory_pool.free_all_blocks()
 
 
+@cp.testing.gpu
 def test_paganin_filter():
     # --- testing the Paganin filter on tomo_standard ---#
     filtered_data = paganin_filter(data)

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -18,6 +18,7 @@ host_flats = datafile['flats']
 host_darks = datafile['darks']
 
 
+@cp.testing.gpu
 def test_stripe_removal():
     data = cp.asarray(host_data)
     flats = cp.asarray(host_flats)

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -14,6 +14,7 @@ host_flats = datafile['flats']
 host_darks = datafile['darks']
 
 
+@cp.testing.gpu
 def test_find_center_vo_cupy():
     data = cp.asarray(host_data)
     flats = cp.asarray(host_flats)


### PR DESCRIPTION
Now we can run GPU and CPU tests separately:
```console
$ pytest -v -m gpu
===================================== test session starts =====================================
platform linux -- Python 3.9.15, pytest-7.2.0, pluggy-1.0.0 -- /dls/science/users/qfc83269/condaenvs/httomolib/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/qfc83269/Applications/oss/httomolib, configfile: pyproject.toml, testpaths: tests
plugins: xdist-3.1.0
collected 13 items / 6 deselected / 7 selected                                                

tests/test_pipeline.py::test_cpu_vs_gpu PASSED                                          [ 14%]
tests/test_prep/test_alignment.py::test_correct_distortion PASSED                       [ 28%]
tests/test_prep/test_normalize.py::test_normalize PASSED                                [ 42%]
tests/test_prep/test_phase.py::test_fresnel_filter PASSED                               [ 57%]
tests/test_prep/test_phase.py::test_paganin_filter PASSED                               [ 71%]
tests/test_prep/test_stripe.py::test_stripe_removal PASSED                              [ 85%]
tests/test_recon/test_recon.py::test_find_center_vo_cupy PASSED                         [100%]

============================== 7 passed, 6 deselected in 18.39s ===============================

$ pytest -v -m "not gpu"
===================================== test session starts =====================================
platform linux -- Python 3.9.15, pytest-7.2.0, pluggy-1.0.0 -- /dls/science/users/qfc83269/condaenvs/httomolib/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/qfc83269/Applications/oss/httomolib, configfile: pyproject.toml, testpaths: tests
plugins: xdist-3.1.0
collected 13 items / 7 deselected / 6 selected                                                

tests/test_misc/test_corr.py::test_inpainting_filter3d PASSED                           [ 16%]
tests/test_misc/test_images.py::test_save_to_images PASSED                              [ 33%]
tests/test_misc/test_segm.py::test_binary_thresholding PASSED                           [ 50%]
tests/test_prep/test_stripe.py::test_detect_stripes PASSED                              [ 66%]
tests/test_prep/test_stripe.py::test_merge_stripes PASSED                               [ 83%]
tests/test_recon/test_recon.py::test_find_center_360 PASSED                             [100%]

========================= 6 passed, 7 deselected in 69.84s (0:01:09) ==========================
```