### PR TITLE
Test refactorings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,104 @@
+# Defines common fixtures and makes them available to all tests
+
+import pytest
+import os
+import numpy as np
+import cupy as cp
+
+CUR_DIR = os.path.abspath(os.path.dirname(__file__))
+
+
+@pytest.fixture(scope="session")
+def test_data_path():
+    return os.path.join(CUR_DIR, "test_data")
+
+
+@pytest.fixture(scope="session")
+def distortion_correction_path(test_data_path):
+    return os.path.join(test_data_path, "distortion-correction")
+
+
+# only load from disk once per session, and we use np.copy for the elements,
+# to ensure data in this loaded file stays as originally loaded
+@pytest.fixture(scope="session")
+def data_file(test_data_path):
+    in_file = os.path.join(test_data_path, "tomo_standard.npz")
+    return np.load(in_file)
+
+
+@pytest.fixture
+def ensure_clean_memory():
+    cp.get_default_memory_pool().free_all_blocks()
+    return None
+
+
+@pytest.fixture
+def host_data(data_file):
+    return np.copy(data_file["data"])
+
+
+@pytest.fixture
+def data(host_data, ensure_clean_memory):
+    return cp.asarray(host_data)
+
+
+@pytest.fixture
+def host_flats(data_file):
+    return np.copy(data_file["flats"])
+
+
+@pytest.fixture
+def flats(host_flats, ensure_clean_memory):
+    return cp.asarray(host_flats)
+
+
+@pytest.fixture
+def host_darks(
+    data_file,
+):
+    return np.copy(data_file["darks"])
+
+
+@pytest.fixture
+def darks(host_darks, ensure_clean_memory):
+    return cp.asarray(host_darks)
+
+
+@pytest.fixture
+def host_angles(data_file):
+    return np.copy(data_file["angles"])
+
+
+@pytest.fixture
+def angles(host_angles, ensure_clean_memory):
+    return cp.asarray(host_angles)
+
+
+@pytest.fixture
+def host_angles_total(data_file):
+    return np.copy(data_file["angles_total"])
+
+
+@pytest.fixture
+def angles_total(host_angles_total, ensure_clean_memory):
+    return cp.asarray(host_angles_total)
+
+
+@pytest.fixture
+def host_detector_y(data_file):
+    return np.copy(data_file["detector_y"])
+
+
+@pytest.fixture
+def detector_y(host_detector_y, ensure_clean_memory):
+    return cp.asarray(host_detector_y)
+
+
+@pytest.fixture
+def host_detector_x(data_file):
+    return np.copy(data_file["detector_x"])
+
+
+@pytest.fixture
+def detector_x(host_detector_x, ensure_clean_memory):
+    return cp.asarray(host_detector_x)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,10 @@
 # Defines common fixtures and makes them available to all tests
 
-import pytest
 import os
-import numpy as np
+
 import cupy as cp
+import numpy as np
+import pytest
 
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,7 @@ def distortion_correction_path(test_data_path):
 @pytest.fixture(scope="session")
 def data_file(test_data_path):
     in_file = os.path.join(test_data_path, "tomo_standard.npz")
+    # keys: data, flats, darks, angles, angles_total, detector_y, detector_x
     return np.load(in_file)
 
 

--- a/tests/test_misc/test_corr.py
+++ b/tests/test_misc/test_corr.py
@@ -1,20 +1,15 @@
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose
 
 from httomolib.misc.corr import inpainting_filter3d
 
-# --- Tomo standard data ---#
-in_file = 'tests/test_data/tomo_standard.npz'
-datafile = np.load(in_file)
-host_data = datafile['data']
 eps = 1e-6
 
 
-def test_inpainting_filter3d():
+def test_inpainting_filter3d(host_data):
     mask = np.zeros(shape=host_data.shape)
     filtered_data = inpainting_filter3d(host_data, mask)
-    for _ in range(5):
-        assert_allclose(np.min(filtered_data), 62.0)
-        assert_allclose(np.max(filtered_data), 1136.0)
-        assert_allclose(np.mean(filtered_data), 809.04987, rtol=eps)
+    
+    assert_allclose(np.min(filtered_data), 62.0)
+    assert_allclose(np.max(filtered_data), 1136.0)
+    assert_allclose(np.mean(filtered_data), 809.04987, rtol=eps)

--- a/tests/test_misc/test_corr.py
+++ b/tests/test_misc/test_corr.py
@@ -1,7 +1,6 @@
 import numpy as np
-from numpy.testing import assert_allclose
-
 from httomolib.misc.corr import inpainting_filter3d
+from numpy.testing import assert_allclose
 
 eps = 1e-6
 

--- a/tests/test_misc/test_images.py
+++ b/tests/test_misc/test_images.py
@@ -1,38 +1,36 @@
-import os
-
 import numpy as np
 from PIL import Image
+import pathlib
 
 from httomolib.misc.images import save_to_images
 
-# --- Tomo standard data ---#
-in_file = 'tests/test_data/tomo_standard.npz'
-datafile = np.load(in_file)
-host_data = datafile['data']
 
-
-def test_save_to_images():    
-    #--- Test for bits=8
-    save_to_images(host_data, 'save_to_images', bits=8)
+def test_save_to_images_8bit(host_data, tmp_path: pathlib.Path):
+    # --- Test for bits=8
+    save_to_images(host_data, tmp_path / "save_to_images", bits=8)
     #: check that the folder is created
-    assert os.path.exists('save_to_images/images/images8bit_tif/')
+    folder = tmp_path / "save_to_images" / "images" / "images8bit_tif"
+    assert folder.exists()
 
-    #: check that the number of files is correct
-    nfiles = len(os.listdir('save_to_images/images/images8bit_tif/'))
-    assert nfiles == 180
-
-    #: check that all files are tif
-    for file in os.listdir('save_to_images/images/images8bit_tif/'):
-        assert file.endswith('.tif')
+    nfiles = len(list(folder.glob("*")))
+    assert nfiles == 180  #: check that the number of files is correct
+    assert len(list(folder.glob("*.tif"))) == nfiles  #: check that all files are tif
 
     #: check that the image size is correct
-    imarray = np.array(
-        Image.open('save_to_images/images/images8bit_tif/00015.tif'))
+    imarray = np.array(Image.open(folder / "00015.tif"))
     assert imarray.shape == (128, 160)
 
-    #--- Test for bits=4423
-    save_to_images(host_data, 'save_to_images',
-        subfolder_name='test', file_format='png', bits=4423)
-    assert os.path.exists('save_to_images/test/images32bit_png/')
-    for file in os.listdir('save_to_images/test/images32bit_png/'):
-        assert file.endswith('.png')
+
+def test_save_to_images_4423bit(host_data, tmp_path: pathlib.Path):
+    # --- Test for bits=4423
+    save_to_images(
+        host_data,
+        tmp_path / "save_to_images",
+        subfolder_name="test",
+        file_format="png",
+        bits=4423,
+    )
+
+    folder = tmp_path / "save_to_images" / "test" / "images32bit_png"
+    assert folder.exists()
+    assert len(list(folder.glob("*.png"))) == 180

--- a/tests/test_misc/test_images.py
+++ b/tests/test_misc/test_images.py
@@ -1,8 +1,8 @@
-import numpy as np
-from PIL import Image
 import pathlib
 
+import numpy as np
 from httomolib.misc.images import save_to_images
+from PIL import Image
 
 
 def test_save_to_images_8bit(host_data, tmp_path: pathlib.Path):

--- a/tests/test_misc/test_segm.py
+++ b/tests/test_misc/test_segm.py
@@ -1,5 +1,4 @@
 import numpy as np
-
 from httomolib.misc.segm import binary_thresholding
 
 

--- a/tests/test_misc/test_segm.py
+++ b/tests/test_misc/test_segm.py
@@ -1,22 +1,17 @@
 import numpy as np
-import pytest
-from numpy.testing import assert_allclose
 
 from httomolib.misc.segm import binary_thresholding
 
-# --- Tomo standard data ---#
-in_file = 'tests/test_data/tomo_standard.npz'
-datafile = np.load(in_file)
-host_data = datafile['data']
+
+def test_binary_thresholding_zeros():
+    data = np.zeros(shape=(100, 100, 100))
+    binary_mask = binary_thresholding(data, 0.5)
+
+    assert np.all(binary_mask == 0)
 
 
-def test_binary_thresholding():
-    _data = np.zeros(shape=(100, 100, 100))
-    _binary_mask = binary_thresholding(_data, 0.5)
-    for _ in range(5):
-        assert np.all(_binary_mask == 0)
-
+def test_binary_thresholding_data(host_data):
     #: testing binary_thresholding on tomo_standard data
     binary_mask = binary_thresholding(host_data, 0.1, otsu=True, axis=2)
-    for _ in range(5):
-        assert np.sum(binary_mask) == 2694904
+
+    assert np.sum(binary_mask) == 2694904

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,11 +1,9 @@
 import cupy as cp
 import numpy as np
 from cupy.testing import assert_allclose
-
 from httomolib.prep.normalize import normalize_cupy
 from httomolib.prep.stripe import remove_stripe_based_sorting_cupy
 from httomolib.recon.rotation import find_center_vo_cupy
-
 from tomopy.prep.normalize import normalize
 from tomopy.prep.stripe import remove_stripe_based_sorting
 from tomopy.recon.rotation import find_center_vo

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,5 +1,4 @@
 import cupy as cp
-import h5py
 import numpy as np
 from cupy.testing import assert_allclose
 
@@ -13,18 +12,17 @@ from tomopy.recon.rotation import find_center_vo
 
 
 @cp.testing.gpu
-def test_cpu_vs_gpu():
+def test_cpu_vs_gpu(host_data, host_flats, host_darks):
     #--- GPU pipeline tested on `tomo_standard` ---#
 
-    in_file = 'tests/test_data/tomo_standard.npz'
-    datafile = np.load(in_file)
-    host_data = np.float32(datafile['data'])
-    host_flats = np.float32(datafile['flats'])
-    host_darks = np.float32(datafile['darks'])
+    host_data = np.float32(host_data)
+    host_flats = np.float32(host_flats)
+    host_darks = np.float32(host_darks)
 
-    data = cp.asarray(host_data, dtype="float32")
-    flats = cp.asarray(host_flats, dtype="float32")
-    darks = cp.asarray(host_darks, dtype="float32")
+    # transferring explicitly here to keep the float32 type (instead of using fixture)
+    data = cp.asarray(host_data)
+    flats = cp.asarray(host_flats)
+    darks = cp.asarray(host_darks)
 
     #: Normalize the data first
     data_normalize_cupy = normalize_cupy(data, flats, darks, cutoff=15.0)

--- a/tests/test_prep/test_alignment.py
+++ b/tests/test_prep/test_alignment.py
@@ -1,5 +1,8 @@
+import os
 import cupy as cp
-from cupy.testing import assert_allclose
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
 from imageio.v2 import imread
 
 from httomolib.prep.alignment import (
@@ -9,58 +12,38 @@ from httomolib.prep.alignment import (
 
 
 @cp.testing.gpu
-def test_correct_distortion():
-    distortion_coeffs_path = \
-        'tests/test_data/distortion-correction/distortion-coeffs.txt'
+@pytest.mark.parametrize(
+    "image, max_value, mean_value",
+    [
+        ("dot_pattern_03.tif", 255, 200.16733869461675),
+        ("peppers.tif", 228, 95.51871109008789),
+        ("cameraman.tif", 254, 122.2400016784668),
+    ],
+    ids=["dot_pattern_03", "peppers", "cameraman"],
+)
+@pytest.mark.parametrize(
+    "implementation",
+    [distortion_correction_proj_cupy, distortion_correction_proj_discorpy_cupy],
+    ids=["cupy", "tomopy"],
+)
+def test_correct_distortion(
+    distortion_correction_path,
+    ensure_clean_memory,
+    image,
+    implementation,
+    max_value,
+    mean_value,
+):
+    distortion_coeffs_path = os.path.join(
+        distortion_correction_path, "distortion-coeffs.txt"
+    )
 
-    path = "tests/test_data/distortion-correction/dot_pattern_03.tif"
+    path = os.path.join(distortion_correction_path, image)
     im_host = imread(path)
     im = cp.asarray(im_host)
 
-    preview = {
-        'starts': [0, 0],
-        'stops': [im.shape[0], im.shape[1]],
-        'steps': [1, 1]
-    }
-    corrected_data = distortion_correction_proj_cupy(
-        im, distortion_coeffs_path, preview)
+    preview = {"starts": [0, 0], "stops": [im.shape[0], im.shape[1]], "steps": [1, 1]}
+    corrected_data = implementation(im, distortion_coeffs_path, preview).get()
 
-    for _ in range(5):
-        assert_allclose(cp.mean(corrected_data), 200.16733869461675)
-        assert cp.max(corrected_data) == 255
-
-    #: test the implementation from tomopy
-    corrected_data = distortion_correction_proj_discorpy_cupy(
-        im, distortion_coeffs_path, preview)
-    for _ in range(5):
-        assert_allclose(cp.mean(corrected_data), 200.193982357142)
-        assert cp.max(corrected_data) == 255
-
-    peppers_path = "tests/test_data/distortion-correction/peppers.tif"
-    im = cp.asarray(imread(peppers_path))
-    corrected_data = distortion_correction_proj_cupy(
-        im, distortion_coeffs_path, preview)
-
-    for _ in range(5):
-        assert_allclose(cp.mean(corrected_data), 95.51871109008789)
-        assert cp.max(corrected_data) == 228
-
-    #: test the implementation from tomopy
-    corrected_data = distortion_correction_proj_discorpy_cupy(
-        im, distortion_coeffs_path, preview)
-    for _ in range(5):
-        assert_allclose(cp.mean(corrected_data), 87.76617813110352)
-        assert cp.max(corrected_data) == 228
-
-    cameraman_path = "tests/test_data/distortion-correction/cameraman.tif"
-    im = cp.asarray(imread(cameraman_path))
-    corrected_data = distortion_correction_proj_cupy(
-        im, distortion_coeffs_path, preview)
-
-    for _ in range(5):
-        assert_allclose(cp.mean(corrected_data), 122.2400016784668)
-        assert cp.max(corrected_data) == 254
-
-    # free up GPU memory
-    im, corrected_data = None, None
-    cp._default_memory_pool.free_all_blocks()
+    assert_allclose(np.mean(corrected_data), mean_value)
+    assert np.max(corrected_data) == max_value

--- a/tests/test_prep/test_alignment.py
+++ b/tests/test_prep/test_alignment.py
@@ -1,14 +1,14 @@
 import os
+
 import cupy as cp
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
-from imageio.v2 import imread
-
 from httomolib.prep.alignment import (
     distortion_correction_proj_cupy,
     distortion_correction_proj_discorpy_cupy,
 )
+from imageio.v2 import imread
+from numpy.testing import assert_allclose
 
 
 @cp.testing.gpu

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -1,9 +1,8 @@
 import cupy as cp
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
-
 from httomolib.prep.normalize import normalize_cupy
+from numpy.testing import assert_allclose
 
 
 @cp.testing.gpu

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -21,12 +21,8 @@ def test_normalize_1D_raises(data, flats, darks):
 
 @cp.testing.gpu
 def test_normalize(data, flats, darks):
-    # testing cupy implementation for normalization
-    data_min = np.array(-0.16163824, dtype=cp.float32)
-    data_max = np.array(2.7530956, dtype=cp.float32)
-
     #--- testing normalize_cupy  ---#
     data_normalize = cp.asnumpy(normalize_cupy(data, flats, darks, cutoff=10, minus_log=True))
     
-    assert_allclose(np.min(data_normalize), data_min, rtol=1e-06)
-    assert_allclose(np.max(data_normalize), data_max, rtol=1e-06)
+    assert_allclose(np.min(data_normalize), -0.16163824, rtol=1e-06)
+    assert_allclose(np.max(data_normalize), 2.7530956, rtol=1e-06)

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -1,41 +1,32 @@
 import cupy as cp
 import numpy as np
 import pytest
-from cupy.testing import assert_allclose
+from numpy.testing import assert_allclose
 
 from httomolib.prep.normalize import normalize_cupy
 
 
 @cp.testing.gpu
-def test_normalize():
-    # testing cupy implementation for normalization
-
-    in_file = 'tests/test_data/tomo_standard.npz'
-    datafile = np.load(in_file)
-    # keys: data, flats, darks, angles, angles_total, detector_y, detector_x
-    host_data = datafile['data']
-    host_flats = datafile['flats']
-    host_darks = datafile['darks']
-
-    data = cp.asarray(host_data)
-    flats = cp.asarray(host_flats)
-    darks = cp.asarray(host_darks)
-
-    data_min = cp.array(-0.16163824, dtype=cp.float32)
-    data_max = cp.array(2.7530956, dtype=cp.float32)
-
+def test_normalize_1D_raises(data, flats, darks):
     _data_1d = cp.ones(10)
+
     #: data cannot be a 1D array
-    pytest.raises(ValueError, lambda: normalize_cupy(_data_1d, flats, darks))
+    with pytest.raises(ValueError):
+        normalize_cupy(_data_1d, flats, darks)
+
     #: flats cannot be a 1D array
-    pytest.raises(ValueError, lambda: normalize_cupy(data, _data_1d, darks))
+    with pytest.raises(ValueError):
+        normalize_cupy(data, _data_1d, darks)
+
+
+@cp.testing.gpu
+def test_normalize(data, flats, darks):
+    # testing cupy implementation for normalization
+    data_min = np.array(-0.16163824, dtype=cp.float32)
+    data_max = np.array(2.7530956, dtype=cp.float32)
 
     #--- testing normalize_cupy  ---#
-    data_normalize_cupy = normalize_cupy(data, flats, darks, cutoff=10, minus_log=True)
-    for _ in range(10):
-        assert_allclose(cp.min(data_normalize_cupy), data_min, rtol=1e-06)
-        assert_allclose(cp.max(data_normalize_cupy), data_max, rtol=1e-06)
-
-    #: free up GPU memory by no longer referencing the variables
-    data_normalize_cupy = flats = darks = data_min = data_max = _data_1d = None
-    cp._default_memory_pool.free_all_blocks()
+    data_normalize = cp.asnumpy(normalize_cupy(data, flats, darks, cutoff=10, minus_log=True))
+    
+    assert_allclose(np.min(data_normalize), data_min, rtol=1e-06)
+    assert_allclose(np.max(data_normalize), data_max, rtol=1e-06)

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -93,10 +93,7 @@ def test_retrieve_phase(data):
 
 @cp.testing.gpu
 def test_retrieve_phase_energy100_nopad(data):
-    # TODO: retrieve_phase modifies data in-place, and reference data was generated
-    # from calling it without params first. The reference should be re-based
-    retrieve_phase(data)
     phase_data = retrieve_phase(data, dist=34.3, energy=100.0, pad=False).get()
 
-    assert_allclose(np.mean(phase_data), 978.7444444444444, rtol=1e-7)
-    assert_allclose(np.std(phase_data), 8.995135859774523, rtol=1e-7)
+    assert_allclose(np.mean(phase_data), 979.527778, rtol=1e-7)
+    assert_allclose(np.std(phase_data), 30.053735, rtol=1e-7)

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -1,7 +1,7 @@
 import cupy as cp
 import numpy as np
 import pytest
-from cupy.testing import assert_allclose
+from numpy.testing import assert_allclose
 
 from httomolib.prep.phase import (
     fresnel_filter,
@@ -9,84 +9,94 @@ from httomolib.prep.phase import (
     retrieve_phase,
 )
 
-in_file = 'tests/test_data/tomo_standard.npz'
-datafile = np.load(in_file)
-host_data = datafile['data']
-data = cp.array(host_data)
 eps = 1e-6
 
 
 @cp.testing.gpu
-def test_fresnel_filter():
+def test_fresnel_filter_projection(data):
     # --- testing the Fresnel filter on tomo_standard ---#
-    pattern = 'PROJECTION'
+    pattern = "PROJECTION"
     ratio = 100.0
-    filtered_data = fresnel_filter(data, pattern, ratio)
+    filtered_data = fresnel_filter(data, pattern, ratio).get()
 
-    for _ in range(5):
-        assert_allclose(cp.mean(filtered_data), 802.1125)
-        assert_allclose(cp.max(filtered_data), 1039.5293)
-        assert_allclose(cp.min(filtered_data), 95.74562)
-
-    pattern = 'SINOGRAM'
-    filtered_data = fresnel_filter(data, pattern, ratio)
-    for _ in range(5):
-        assert_allclose(cp.mean(filtered_data), 806.74347, rtol=eps)
-        assert_allclose(cp.max(filtered_data), 1063.7007)
-        assert_allclose(cp.min(filtered_data), 87.91508)
-
-    _data = cp.ones(10)
-    pytest.raises(ValueError, lambda: fresnel_filter(_data, pattern, ratio))
-
-    # free up GPU memory by no longer referencing the variable
-    filtered_data = _data = None
-    cp._default_memory_pool.free_all_blocks()
+    assert_allclose(np.mean(filtered_data), 802.1125, rtol=eps)
+    assert_allclose(np.max(filtered_data), 1039.5293)
+    assert_allclose(np.min(filtered_data), 95.74562)
 
 
 @cp.testing.gpu
-def test_paganin_filter():
+def test_fresnel_filter_sinogram(data):
+    pattern = "SINOGRAM"
+    ratio = 100.0
+    filtered_data = fresnel_filter(data, pattern, ratio).get()
+
+    assert_allclose(np.mean(filtered_data), 806.74347, rtol=eps)
+    assert_allclose(np.max(filtered_data), 1063.7007)
+    assert_allclose(np.min(filtered_data), 87.91508)
+
+
+@cp.testing.gpu
+def test_fresnel_filter_1D_raises(ensure_clean_memory):
+    _data = cp.ones(10)
+    with pytest.raises(ValueError):
+        fresnel_filter(_data, "SINOGRAM", 100.0)
+
+
+@cp.testing.gpu
+def test_paganin_filter(data):
     # --- testing the Paganin filter on tomo_standard ---#
-    filtered_data = paganin_filter(data)
+    filtered_data = paganin_filter(data).get()
 
-    for _ in range(5):
-        assert filtered_data.ndim == 3
-        assert_allclose(cp.mean(filtered_data), -770.5339, rtol=eps)
-        assert_allclose(cp.max(filtered_data), -679.80945, rtol=eps)
-
-    filtered_data = paganin_filter(data, energy=100.0)
-
-    assert_allclose(cp.mean(filtered_data), -778.61926, rtol=1e-05)
-    assert_allclose(cp.min(filtered_data), -808.9013, rtol=eps)
-
-    filtered_data = paganin_filter(data, pad_method='mean')
-
-    assert_allclose(cp.mean(filtered_data), -765.3401, rtol=eps)
-    assert_allclose(cp.min(filtered_data), -793.68787, rtol=eps)
-
-    _data = cp.ones(10)
-    pytest.raises(ValueError, lambda: paganin_filter(_data))
-
-    # free up GPU memory by no longer referencing the variable
-    filtered_data, _data = None, None
-    cp._default_memory_pool.free_all_blocks()
+    assert filtered_data.ndim == 3
+    assert_allclose(np.mean(filtered_data), -770.5339, rtol=eps)
+    assert_allclose(np.max(filtered_data), -679.80945, rtol=eps)
 
 
 @cp.testing.gpu
-def test_retrieve_phase():
+def test_paganin_filter_energy100(data):
+    filtered_data = paganin_filter(data, energy=100.0).get()
+
+    assert_allclose(np.mean(filtered_data), -778.61926, rtol=1e-05)
+    assert_allclose(np.min(filtered_data), -808.9013, rtol=eps)
+
+
+@cp.testing.gpu
+def test_paganin_filter_padmean(data):
+    filtered_data = paganin_filter(data, pad_method="mean").get()
+
+    assert_allclose(np.mean(filtered_data), -765.3401, rtol=eps)
+    assert_allclose(np.min(filtered_data), -793.68787, rtol=eps)
+
+
+@cp.testing.gpu
+def test_paganin_filter_1D_raises(ensure_clean_memory):
+    _data = cp.ones(10)
+    with pytest.raises(ValueError):
+        paganin_filter(_data)
+
+
+@cp.testing.gpu
+def test_retrieve_phase_1D_raises(ensure_clean_memory):
     #: testing the phase retrieval on tomo_standard
     _data = cp.ones(10)
-    pytest.raises(ValueError, lambda: retrieve_phase(_data))
+    with pytest.raises(ValueError):
+        retrieve_phase(_data)
 
-    phase_data = retrieve_phase(data)
+
+@cp.testing.gpu
+def test_retrieve_phase(data):
+    phase_data = retrieve_phase(data).get()
     assert phase_data.shape == (180, 128, 160)
-    assert cp.sum(phase_data) == 2994544952
-    assert_allclose(cp.mean(phase_data), 812.3223068576389, rtol=1e-7)
+    assert np.sum(phase_data) == 2994544952
+    assert_allclose(np.mean(phase_data), 812.3223068576389, rtol=1e-7)
 
-    phase_data = retrieve_phase(data, dist=34.3, energy=100.0, pad=False)
-    for _ in range(3):
-        assert_allclose(cp.mean(phase_data), 978.7444444444444, rtol=1e-7)
-        assert_allclose(cp.std(phase_data), 8.995135859774523, rtol=1e-7)
 
-    # free up GPU memory by no longer referencing the variable
-    phase_data, _data = None, None
-    cp._default_memory_pool.free_all_blocks()
+@cp.testing.gpu
+def test_retrieve_phase_energy100_nopad(data):
+    # TODO: retrieve_phase modifies data in-place, and reference data was generated
+    # from calling it without params first. The reference should be re-based
+    retrieve_phase(data)
+    phase_data = retrieve_phase(data, dist=34.3, energy=100.0, pad=False).get()
+
+    assert_allclose(np.mean(phase_data), 978.7444444444444, rtol=1e-7)
+    assert_allclose(np.std(phase_data), 8.995135859774523, rtol=1e-7)

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -1,13 +1,8 @@
 import cupy as cp
 import numpy as np
 import pytest
+from httomolib.prep.phase import fresnel_filter, paganin_filter, retrieve_phase
 from numpy.testing import assert_allclose
-
-from httomolib.prep.phase import (
-    fresnel_filter,
-    paganin_filter,
-    retrieve_phase,
-)
 
 eps = 1e-6
 

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -1,12 +1,11 @@
 import cupy as cp
 import numpy as np
-from numpy.testing import assert_allclose
-
 from httomolib.prep.normalize import normalize_cupy
 from httomolib.prep.stripe import (
     remove_stripe_based_sorting_cupy,
     remove_stripes_titarenko_cupy,
 )
+from numpy.testing import assert_allclose
 
 
 @cp.testing.gpu

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -24,10 +24,8 @@ def test_stripe_removal_titarenko_cupy(data, flats, darks):
 def test_stripe_removal_sorting_cupy(data, flats, darks):
     # --- testing the CuPy port of TomoPy's implementation ---#
     data = normalize_cupy(data, flats, darks, cutoff=10, minus_log=True)
-    # TODO: modifies data in place - should make test independent
-    remove_stripes_titarenko_cupy(data)  
     corrected_data = remove_stripe_based_sorting_cupy(data).get()
 
-    assert_allclose(np.mean(corrected_data), 0.2886111, rtol=1e-06)
-    assert_allclose(np.max(corrected_data), 2.4899824, rtol=1e-07)
-    assert_allclose(np.min(corrected_data), -0.1081188, rtol=1e-07)
+    assert_allclose(np.mean(corrected_data), 0.288198, rtol=1e-06)
+    assert_allclose(np.max(corrected_data), 2.5242403, rtol=1e-07)
+    assert_allclose(np.min(corrected_data), -0.10906063, rtol=1e-07)

--- a/tests/test_recon/test_algorithm.py
+++ b/tests/test_recon/test_algorithm.py
@@ -1,19 +1,12 @@
 import numpy as np
-import pytest
 from numpy.testing import assert_allclose
 
 from httomolib.recon.algorithm import reconstruct_tomobar, reconstruct_tomopy
 
 from tomopy.prep.normalize import normalize
 
-in_file = 'tests/test_data/tomo_standard.npz'
-datafile = np.load(in_file)
-host_data = datafile['data']
-host_flats = datafile['flats']
-host_darks = datafile['darks']
 
-
-def test_reconstruct_methods():
+def test_reconstruct_methods(host_data, host_flats, host_darks):
     cor = 79.5 #: center of rotation for tomo_standard
     data = normalize(host_data, host_flats, host_darks, cutoff=15.0)
     angles = np.linspace(0. * np.pi / 180., 180. * np.pi / 180., data.shape[0])
@@ -21,12 +14,10 @@ def test_reconstruct_methods():
     #--- reconstructing the data ---#
     recon_data = reconstruct_tomobar(data, angles, cor, algorithm="FBP3D_host")
     recon_data_tomopy = reconstruct_tomopy(data, angles, cor, algorithm="FBP_CUDA")
+
     assert recon_data.shape == (128, 160, 160)
+    assert_allclose(np.mean(recon_data), -0.00047175083, rtol=1e-07, atol=1e-8)
+    assert_allclose(np.std(recon_data), 0.0034436132, rtol=1e-07, atol=1e-8)
 
-    for _ in range(3):
-        assert_allclose(np.mean(recon_data), -0.00047175083, rtol=1e-07)
-        assert_allclose(np.std(recon_data), 0.0034436132, rtol=1e-07)
-
-    for _ in range(3):              
-        assert_allclose(np.mean(recon_data_tomopy), 0.008697214, rtol=1e-07)
-        assert_allclose(np.std(recon_data_tomopy), 0.009089365, rtol=1e-07)
+    assert_allclose(np.mean(recon_data_tomopy), 0.008697214, rtol=1e-07, atol=1e-8)
+    assert_allclose(np.std(recon_data_tomopy), 0.009089365, rtol=1e-07, atol=1e-8)

--- a/tests/test_recon/test_algorithm.py
+++ b/tests/test_recon/test_algorithm.py
@@ -1,8 +1,6 @@
 import numpy as np
-from numpy.testing import assert_allclose
-
 from httomolib.recon.algorithm import reconstruct_tomobar, reconstruct_tomopy
-
+from numpy.testing import assert_allclose
 from tomopy.prep.normalize import normalize
 
 

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -1,49 +1,40 @@
 import cupy as cp
 import numpy as np
 import pytest
-from cupy.testing import assert_allclose
+from numpy.testing import assert_allclose
 
 from httomolib.prep.normalize import normalize_cupy
 from httomolib.recon.rotation import find_center_360, find_center_vo_cupy
 
-in_file = 'tests/test_data/tomo_standard.npz'
-datafile = np.load(in_file)
-# keys: data, flats, darks, angles, angles_total, detector_y, detector_x
-host_data = datafile['data']
-host_flats = datafile['flats']
-host_darks = datafile['darks']
-
 
 @cp.testing.gpu
-def test_find_center_vo_cupy():
-    data = cp.asarray(host_data)
-    flats = cp.asarray(host_flats)
-    darks = cp.asarray(host_darks)
+def test_find_center_vo_cupy(data, flats, darks):
     data = normalize_cupy(data, flats, darks)
 
     #--- testing the center of rotation on tomo_standard ---#
-    cor = find_center_vo_cupy(data)
-    for _ in range(10):
-        assert_allclose(cor, 79.5)
+    cor = find_center_vo_cupy(data).get()
 
+    assert_allclose(cor, 79.5)
+
+
+@cp.testing.gpu
+def test_find_center_vo_cupy(ensure_clean_memory):
     mat = cp.ones(shape=(103, 450, 230))
-    cor = find_center_vo_cupy(mat)
+    cor = find_center_vo_cupy(mat).get()
     assert_allclose(cor, 59.0)
 
-    # free up GPU memory by no longer referencing the variables
-    data, flats, darks = None, None, None
-    cp._default_memory_pool.free_all_blocks()
 
-
-def test_find_center_360():
+def test_find_center_360_ones():
     mat = np.ones(shape=(100, 100, 100))
     (cor, overlap, side, overlap_position) = find_center_360(mat[:, 2, :])
-    for _ in range(5):
-        assert_allclose(cor, 5.0)
-        assert_allclose(overlap, 12.0)
-        assert side == 0
-        assert_allclose(overlap_position, 7.0)
 
+    assert_allclose(cor, 5.0)
+    assert_allclose(overlap, 12.0)
+    assert side == 0
+    assert_allclose(overlap_position, 7.0)
+
+
+def test_find_center_360_data(host_data):
     eps = 1e-5
     (cor, overlap, side, overlap_pos) = find_center_360(host_data[:, 10, :])
     assert_allclose(cor, 118.56627, rtol=eps)
@@ -55,6 +46,11 @@ def test_find_center_360():
     assert cor.dtype == np.float32
     assert overlap.dtype == np.float32
 
+
+def test_find_center_360_1D_raises(host_data):
     #: 360-degree sinogram must be a 2d array
-    pytest.raises(ValueError, lambda: find_center_360(host_data[:, 10, 10]))
-    pytest.raises(ValueError, lambda: find_center_360(np.ones(10)))
+
+    with pytest.raises(ValueError):
+        find_center_360(host_data[:, 10, 10])
+    with pytest.raises(ValueError):
+        find_center_360(np.ones(10))

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -1,10 +1,9 @@
 import cupy as cp
 import numpy as np
 import pytest
-from numpy.testing import assert_allclose
-
 from httomolib.prep.normalize import normalize_cupy
 from httomolib.recon.rotation import find_center_360, find_center_vo_cupy
+from numpy.testing import assert_allclose
 
 
 @cp.testing.gpu

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -18,7 +18,7 @@ def test_find_center_vo_cupy(data, flats, darks):
 
 
 @cp.testing.gpu
-def test_find_center_vo_cupy(ensure_clean_memory):
+def test_find_center_vo_cupy_ones(ensure_clean_memory):
     mat = cp.ones(shape=(103, 450, 230))
     cor = find_center_vo_cupy(mat).get()
     assert_allclose(cor, 59.0)


### PR DESCRIPTION
### This PR refactors tests as follows:

- using pytest fixtures to avoid copy/pasting all the data loading
- split up tests that tested several things in a row into standalone tests, to avoid dependence on data and cross-effects and for better results reporting
- parametrize tests where it makes sense
- do assertions / comparisons on the CPU with numpy
- remove repeated assertions of the exact same data - there's no randomness with numpy's assert functions

### Things to note: 

There are 2 TODO comments, showing where a previous function modifies the data in-place, so had to call it again in the split-up test to match the assertions as they were. The reference values for these should ideally be re-based to the single call only.

Further, `numpy` calculates means in a different order to `cupy`, due to the parallel reductions on the GPU. This meant I had to increase tolerances in 2 functions a tiny bit to match the reference - please check this carefully.