### PR TITLE
Performance tests and more precise assertions for paganin filter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,5 +26,5 @@ Run tests
 * Run GPU tests separately with :code:`$ pytest -v -m gpu`.
 * Run CPU tests separately with :code:`$ pytest -v -m "not gpu"`.
 * Run performance tests (only) with :code:`$ pytest --performance`
-  (note that performance tests always fail - the report the execution time in an assertion
+  (note that performance tests always fail - they report the execution time in an assertion
   to see them in the summary easily)

--- a/README.rst
+++ b/README.rst
@@ -25,3 +25,6 @@ Run tests
 * Run all tests with :code:`$ pytest`. To increase verbosity, use :code:`$ pytest -v`.
 * Run GPU tests separately with :code:`$ pytest -v -m gpu`.
 * Run CPU tests separately with :code:`$ pytest -v -m "not gpu"`.
+* Run performance tests (only) with :code:`$ pytest --performance`
+  (note that performance tests always fail - the report the execution time in an assertion
+  to see them in the summary easily)

--- a/httomolib/prep/alignment.py
+++ b/httomolib/prep/alignment.py
@@ -26,6 +26,7 @@ from typing import Dict, List
 
 import cupy as cp
 from cupyx.scipy.ndimage import map_coordinates
+import nvtx
 
 __all__ = [
     'distortion_correction_proj_cupy',
@@ -35,6 +36,7 @@ __all__ = [
 ## %%%%%%%%%%%%%%%%%%%%%%%%%distortion_correction_proj_cupy%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 # CuPy implementation of distortion correction from Savu 
 # TODO: Needs to be implementation from TomoPy
+@nvtx.annotate()
 def distortion_correction_proj_cupy(data: cp.ndarray, metadata_path: str,
                        preview: Dict[str, List[int]],
                        center_from_left: float = None,
@@ -166,6 +168,7 @@ def distortion_correction_proj_cupy(data: cp.ndarray, metadata_path: str,
 # (which is the same as the TomoPy version
 # https://github.com/tomopy/tomopy/blob/c236a2969074f5fc70189fb5545f0a165924f916/source/tomopy/prep/alignment.py#L950-L981
 # but with the additional params `order` and `mode`).
+@nvtx.annotate()
 def distortion_correction_proj_discorpy_cupy(data: cp.ndarray,
                                              metadata_path: str,
                                              preview: Dict[str, List[int]],

--- a/httomolib/prep/normalize.py
+++ b/httomolib/prep/normalize.py
@@ -67,15 +67,6 @@ def normalize_cupy(
     ndarray
         Normalised 3D tomographic data as a CuPy array.
     """
-    print(f"""normalize_cupy:
-            data={data.shape}, {data.dtype}, min={cp.min(data)}, max{cp.max(data)}
-            flats={flats.shape}, {flats.dtype}, min={cp.min(flats)}, max{cp.max(flats)}
-            darks={darks.shape}, {darks.dtype}, min={cp.min(darks)}, max{cp.max(darks)}
-            cutoff={cutoff}
-            minus_log={minus_log}
-            nonnegativity={nonnegativity}
-            remove_nans={remove_nans}
-            """)
     cp.cuda.Device(gpu_id).use()
     
     darks = mean(darks, axis=0, dtype=float32)

--- a/httomolib/prep/normalize.py
+++ b/httomolib/prep/normalize.py
@@ -23,11 +23,13 @@
 
 import cupy as cp
 from cupy import float32, log, mean, ndarray
+import nvtx
 
 __all__ = [
     'normalize_cupy',
 ]
 
+@nvtx.annotate()
 def normalize_cupy(
     data: ndarray,
     flats: ndarray,
@@ -65,6 +67,15 @@ def normalize_cupy(
     ndarray
         Normalised 3D tomographic data as a CuPy array.
     """
+    print(f"""normalize_cupy:
+            data={data.shape}, {data.dtype}, min={cp.min(data)}, max{cp.max(data)}
+            flats={flats.shape}, {flats.dtype}, min={cp.min(flats)}, max{cp.max(flats)}
+            darks={darks.shape}, {darks.dtype}, min={cp.min(darks)}, max{cp.max(darks)}
+            cutoff={cutoff}
+            minus_log={minus_log}
+            nonnegativity={nonnegativity}
+            remove_nans={remove_nans}
+            """)
     cp.cuda.Device(gpu_id).use()
     
     darks = mean(darks, axis=0, dtype=float32)

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -147,6 +147,7 @@ def _make_window(height, width, ratio, pattern):
 
 ## %%%%%%%%%%%%%%%%%%%%%%% paganin_filter %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 #: CuPy implementation of Paganin filter from Savu
+@nvtx.annotate()
 def paganin_filter(
     data: cp.ndarray,
     ratio: float = 250.0,
@@ -256,6 +257,7 @@ def paganin_filter(
 
 ## %%%%%%%%%%%%%%%%%%%%%%% retrieve_phase %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 #: CuPy implementation of retrieve_phase from TomoPy
+@nvtx.annotate()
 def retrieve_phase(
     tomo: cp.ndarray,
     pixel_size: float = 1e-4,

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -24,6 +24,9 @@
 import math
 
 import cupy as cp
+import cupyx
+import numpy as np
+import nvtx
 
 __all__ = [
     'fresnel_filter',

--- a/httomolib/prep/stripe.py
+++ b/httomolib/prep/stripe.py
@@ -24,6 +24,7 @@ import cupy as cp
 import numpy as np
 from cupy import abs, mean, ndarray
 from cupyx.scipy.ndimage import median_filter
+import nvtx
 
 __all__ = [
     'remove_stripe_based_sorting_cupy',
@@ -36,6 +37,7 @@ __all__ = [
 
 ## %%%%%%%%%%%%%%%%% remove_stripe_based_sorting_cupy %%%%%%%%%%%%%%%%%%%%%  ##
 ## Naive CuPy port of the NumPy implementation in TomoPy
+@nvtx.annotate()
 def remove_stripe_based_sorting_cupy(
     data: ndarray,
     size: int = 11,
@@ -73,6 +75,12 @@ def remove_stripe_based_sorting_cupy(
     ----------
     .. [1] https://doi.org/10.1364/OE.26.028396
     """
+    print(f"""remove_stripe_based_sorting_cupy:
+            data={data.shape}, {data.dtype}, min={cp.min(data)}, max{cp.max(data)}
+            size={size}
+            dim={dim}
+            gpu_id={gpu_id}
+            """)
     cp.cuda.Device(gpu_id).use()
 
     matindex = _create_matindex(data.shape[2], data.shape[0])
@@ -125,6 +133,7 @@ def _rs_sort(sinogram, size, matindex, dim):
 
 
 ## %%%%%%%%%%%%%%%%%%% remove_stripes_titarenko_cupy %%%%%%%%%%%%%%%%%%%%%%%  ##
+@nvtx.annotate()
 def remove_stripes_titarenko_cupy(
     data: ndarray,
     beta: float = 0.1,

--- a/httomolib/prep/stripe.py
+++ b/httomolib/prep/stripe.py
@@ -75,12 +75,6 @@ def remove_stripe_based_sorting_cupy(
     ----------
     .. [1] https://doi.org/10.1364/OE.26.028396
     """
-    print(f"""remove_stripe_based_sorting_cupy:
-            data={data.shape}, {data.dtype}, min={cp.min(data)}, max{cp.max(data)}
-            size={size}
-            dim={dim}
-            gpu_id={gpu_id}
-            """)
     cp.cuda.Device(gpu_id).use()
 
     matindex = _create_matindex(data.shape[2], data.shape[0])

--- a/httomolib/recon/algorithm.py
+++ b/httomolib/recon/algorithm.py
@@ -25,6 +25,7 @@ from typing import Optional
 
 import cupy as cp
 import numpy as np
+import nvtx
 
 __all__ = [
     'reconstruct_tomobar',
@@ -32,6 +33,7 @@ __all__ = [
 ]
 
 ## %%%%%%%%%%%%%%%%%%%%%%% ToMoBAR reconstruction %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
+@nvtx.annotate()
 def reconstruct_tomobar(
     data: cp.ndarray,
     angles: np.ndarray,
@@ -40,6 +42,13 @@ def reconstruct_tomobar(
     algorithm: str = 'FBP3D_device',
     gpu_id : int = 0
     ) -> cp.ndarray:
+    print(f"""reconstruct_tomobar:
+            data={data.shape}, {data.dtype}, min={cp.min(data)}, max{cp.max(data)}
+            angles={angles.shape}, {angles.dtype}, min={np.min(angles)}, max={np.max(angles)}
+            center={center}
+            objsize={objsize}
+            algorithm={algorithm}
+            """)
     """
     Perform reconstruction using ToMoBAR wrappers around ASTRA toolbox.
     This is a 3D recon using 3D astra geometry routines.
@@ -151,6 +160,7 @@ def _filtersinc3D_cupy(projection3D):
 
 
 ## %%%%%%%%%%%%%%%%%%%%%%% Tomopy/ASTRA reconstruction %%%%%%%%%%%%%%%%%%%%%%%%%%  ##
+@nvtx.annotate()
 def reconstruct_tomopy(
     data: np.ndarray,
     angles: np.ndarray,

--- a/httomolib/recon/algorithm.py
+++ b/httomolib/recon/algorithm.py
@@ -42,13 +42,6 @@ def reconstruct_tomobar(
     algorithm: str = 'FBP3D_device',
     gpu_id : int = 0
     ) -> cp.ndarray:
-    print(f"""reconstruct_tomobar:
-            data={data.shape}, {data.dtype}, min={cp.min(data)}, max{cp.max(data)}
-            angles={angles.shape}, {angles.dtype}, min={np.min(angles)}, max={np.max(angles)}
-            center={center}
-            objsize={objsize}
-            algorithm={algorithm}
-            """)
     """
     Perform reconstruction using ToMoBAR wrappers around ASTRA toolbox.
     This is a 3D recon using 3D astra geometry routines.

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -79,16 +79,6 @@ def find_center_vo_cupy(
     float
         Rotation axis location.
     """
-    print(f"""find_center_vo_cupy:
-            data={data.shape}, {data.dtype}
-            ind={ind}
-            smin={smin}
-            smax={smax}
-            srad={srad}
-            step={step}
-            ratio={ratio}
-            drop={drop}
-            """)
     return _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop)
 
 

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -29,6 +29,7 @@ import scipy.ndimage as ndi
 from cupy import ndarray
 from cupyx.scipy.ndimage import gaussian_filter, shift
 from scipy import stats
+import nvtx
 
 __all__ = [
     'find_center_vo_cupy',
@@ -36,6 +37,7 @@ __all__ = [
 ]
 
 
+@nvtx.annotate()
 def find_center_vo_cupy(
     data: ndarray,
     ind: int = None,
@@ -77,6 +79,16 @@ def find_center_vo_cupy(
     float
         Rotation axis location.
     """
+    print(f"""find_center_vo_cupy:
+            data={data.shape}, {data.dtype}
+            ind={ind}
+            smin={smin}
+            smax={smax}
+            srad={srad}
+            step={step}
+            ratio={ratio}
+            drop={drop}
+            """)
     return _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop)
 
 
@@ -345,6 +357,7 @@ def _downsample(sino, level, axis):
 
 
 #--- Center of rotation (COR) estimation method ---#
+@nvtx.annotate()
 def find_center_360(
     sino_360: np.ndarray,
     win_width: int = 10,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,32 @@ import pytest
 CUR_DIR = os.path.abspath(os.path.dirname(__file__))
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--performance",
+        action="store_true",
+        default=False,
+        help="run performance tests only",
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "perf: mark test as performance test")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--performance"):
+        skip_other = pytest.mark.skip(reason="not a performance test")
+        for item in items:
+            if "perf" not in item.keywords:
+                item.add_marker(skip_other)
+    else:
+        skip_perf = pytest.mark.skip(reason="performance test - use '--performance' to run")
+        for item in items:
+            if "perf" in item.keywords:
+                item.add_marker(skip_perf)
+
+
 @pytest.fixture(scope="session")
 def test_data_path():
     return os.path.join(CUR_DIR, "test_data")

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -1,6 +1,8 @@
+import time
 import cupy as cp
 import numpy as np
 import pytest
+from cupy.cuda import nvtx
 from httomolib.prep.normalize import normalize_cupy
 from numpy.testing import assert_allclose
 
@@ -25,3 +27,30 @@ def test_normalize(data, flats, darks):
     
     assert_allclose(np.min(data_normalize), -0.16163824, rtol=1e-06)
     assert_allclose(np.max(data_normalize), 2.7530956, rtol=1e-06)
+
+@cp.testing.gpu
+@pytest.mark.perf
+def test_normalize_performance(ensure_clean_memory):
+    # Note: low/high and size values taken from sample2_medium.yaml real run
+    data_host = np.random.randint(low=7515, high=37624, size=(1801, 5, 2560), dtype=np.uint16)
+    flats_host = np.random.randint(low=43397, high=52324, size=(50, 5, 2560), dtype=np.uint16)
+    darks_host = np.random.randint(low=64, high=117, size=(20, 5,2560), dtype=np.uint16)
+    data = cp.asarray(data_host)
+    flats = cp.asarray(flats_host)
+    darks = cp.asarray(darks_host)
+    
+    # run code and time it
+    # do a cold run for warmup
+    normalize_cupy(cp.copy(data), flats, darks, cutoff=10.0, minus_log=True, nonnegativity=False, remove_nans=False)
+    dev = cp.cuda.Device()
+    dev.synchronize()
+    start = time.perf_counter_ns()
+    nvtx.RangePush('Core')
+    for _ in range(10):
+        normalize_cupy(cp.copy(data), flats, darks, cutoff=10.0, minus_log=True, nonnegativity=False, remove_nans=False)
+    nvtx.RangePop()
+    dev.synchronize()
+    end = time.perf_counter_ns()
+    duration_ms = float(end - start) * 1e-6 / 10
+
+    assert "performance in ms" == duration_ms

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -1,4 +1,6 @@
+import time
 import cupy as cp
+from cupy.cuda import nvtx
 import numpy as np
 import pytest
 from httomolib.prep.phase import fresnel_filter, paganin_filter, retrieve_phase
@@ -61,6 +63,58 @@ def test_paganin_filter_padmean(data):
 
     assert_allclose(np.mean(filtered_data), -765.3401, rtol=eps)
     assert_allclose(np.min(filtered_data), -793.68787, rtol=eps)
+    # test a few other slices to ensure shifting etc is right
+    assert_allclose(
+        filtered_data[0, 50, 1:5],
+        [-785.60736, -786.20215, -786.7521, -787.25494],
+        rtol=eps,
+    )
+    assert_allclose(filtered_data[0, 50, 40:42], [-776.6436, -775.1906], rtol=eps)
+    assert_allclose(filtered_data[0, 60:63, 90], [-737.75104, -736.6097, -735.49884])
+
+
+@cp.testing.gpu
+@pytest.mark.perf
+def test_paganin_filter_performance(ensure_clean_memory):
+    # Note: low/high and size values taken from sample2_medium.yaml real run
+    data_host = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0
+    data = cp.asarray(data_host, dtype=np.float32)
+
+    # run code and time it
+    # cold run first
+    paganin_filter(
+        data,
+        ratio=250.0,
+        energy=53.0,
+        distance=1.0,
+        resolution=1.28,
+        pad_y=100,
+        pad_x=100,
+        pad_method="edge",
+        increment=0.0,
+    )
+    dev = cp.cuda.Device()
+    dev.synchronize()
+
+    start = time.perf_counter_ns()
+    nvtx.RangePush("Core")
+    for _ in range(10):
+        paganin_filter(
+            data,
+            ratio=250.0,
+            energy=53.0,
+            distance=1.0,
+            resolution=1.28,
+            pad_y=100,
+            pad_x=100,
+            pad_method="edge",
+            increment=0.0,
+        )
+    nvtx.RangePop()
+    dev.synchronize()
+    duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
+
+    assert "performance in ms" == duration_ms
 
 
 @cp.testing.gpu

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -69,9 +69,10 @@ def test_paganin_filter_padmean(data):
         [-785.60736, -786.20215, -786.7521, -787.25494],
         rtol=eps,
     )
-    assert_allclose(filtered_data[0, 50, 40:42], [-776.6436, -775.1906], rtol=eps)
-    assert_allclose(filtered_data[0, 60:63, 90], [-737.75104, -736.6097, -735.49884])
-
+    assert_allclose(filtered_data[0, 50, 40:42], 
+        [-776.6436, -775.1906], rtol=eps, atol=1e-5)
+    assert_allclose(filtered_data[0, 60:63, 90],
+        [-737.75104, -736.6097, -735.49884], rtol=eps, atol=1e-5)
 
 @cp.testing.gpu
 @pytest.mark.perf


### PR DESCRIPTION
This adds specifically marked performance tests to the test suite. They are not for functional correctness, but for measuring performance only. They need to be marked with `@pytest.mark.perf`, and will only run with users run `pytest --performance`. The execution time is reported in an assertion, and they will always fail. This allows seeing the execution time nicely in the summary. 

It also adds NVTX annotations to all GPU functions, so they can be highlighted in the profiler. (Note that these annotations do no harm if the program is not executed in a profiler).

Further, it extends one of the `pagainin_filter` tests to not only assert the mean and min, but also some specific values. This is to ensure correctness even if the fftshifts and padding might have gone wrong (the mean might still be matching, while specific value might not in that case).