### PR TITLE
Optimised paganin filter for GPU

### DIFF
--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -310,10 +310,9 @@ def paganin_filter(
     else:
         precond_kernel_int(data, data)
 
-    pci1 = cupyx.scipy.fft.fft2(data, axes=(-2, -1))
-    data = None  # allow clearing memory
-    pci1 *= filtercomplex
-    cupyx.scipy.fft.ifft2(pci1, axes=(-2, -1), overwrite_x=True)
+    data = cupyx.scipy.fft.fft2(data, axes=(-2, -1), overwrite_x=True)
+    data *= filtercomplex
+    data = cupyx.scipy.fft.ifft2(data, axes=(-2, -1), overwrite_x=True)
 
     post_kernel = cp.ElementwiseKernel(
         "C pci1, raw float32 increment, raw float32 ratio",
@@ -322,9 +321,9 @@ def paganin_filter(
         name="paganin_post_proc",
         no_return=True,
     )
-    res = cp.empty((pci1.shape[0], height, width), dtype=np.float32)
+    res = cp.empty((data.shape[0], height, width), dtype=np.float32)
     post_kernel(
-        pci1[:, pad_y : pad_y + height, pad_x : pad_x + width], increment, ratio, res
+        data[:, pad_y : pad_y + height, pad_x : pad_x + width], increment, ratio, res
     )
 
     return res

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -315,7 +315,7 @@ def paganin_filter(
     post_kernel = cp.ElementwiseKernel(
         "C pci1, raw float32 increment, raw float32 ratio, raw float32 fft_scale",
         "T out",
-        "out = -0.5 * ratio * log(abs(pci1 * fft_scale) + increment)",
+        "out = -0.5 * ratio * log(abs(pci1) * fft_scale + increment)",
         name="paganin_post_proc",
         no_return=True,
     )

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -236,8 +236,8 @@ def paganin_filter(
 
         float dpx = 1.0f / (width1 * resolution);
         float dpy = 1.0f / (height1 * resolution);
-        float centerx = ceil(width1 / 2.0f) - 1.0f;
-        float centery = ceil(height1 / 2.0f) - 1.0f;
+        int centerx = (width1 + 1) / 2 - 1;
+        int centery = (height1 + 1) / 2 - 1;
 
         float pxx = (px - centerx) * dpx;
         float pyy = (py - centery) * dpy;
@@ -246,15 +246,9 @@ def paganin_filter(
 
         complex<float> value = 1.0f / complex<float>(filter1, filter1);
 
-        // iffshifting positions
-        int xshift = width1 / 2;
-        if (width1 % 2 != 0) {
-            xshift++;
-        }
-        int yshift = height1 / 2;
-        if (height1 % 2 != 0) {
-            yshift++;
-        }
+        // ifftshifting positions
+        int xshift = (width1 + 1) / 2;
+        int yshift = (height1 + 1) / 2;
         int outX = (px + xshift) % width1;
         int outY = (py + yshift) % height1;
 

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -80,7 +80,17 @@ def test_paganin_filter_padmean(data):
 @pytest.mark.perf
 def test_paganin_filter_performance(ensure_clean_memory):
     # Note: low/high and size values taken from sample2_medium.yaml real run
-    data_host = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0
+    
+    # this test needs ~20GB of memory with 1801 - we'll divide depending on GPU memory
+    dev = cp.cuda.Device()
+    mem_80percent = 0.8 * dev.mem_info[0]
+    size = 1801
+    required_mem = 40 * 1024*1024*1024
+    if mem_80percent < required_mem:
+        size = int(np.ceil(size / required_mem * mem_80percent))
+        print(f'Using smaller size of ({size}, 5, 2560) due to memory restrictions')
+
+    data_host = np.random.random_sample(size=(size, 5, 2560)).astype(np.float32) * 2.0
     data = cp.asarray(data_host, dtype=np.float32)
 
     # run code and time it

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -85,7 +85,7 @@ def test_paganin_filter_performance(ensure_clean_memory):
     dev = cp.cuda.Device()
     mem_80percent = 0.8 * dev.mem_info[0]
     size = 1801
-    required_mem = 40 * 1024*1024*1024
+    required_mem = 20 * 1024*1024*1024
     if mem_80percent < required_mem:
         size = int(np.ceil(size / required_mem * mem_80percent))
         print(f'Using smaller size of ({size}, 5, 2560) due to memory restrictions')


### PR DESCRIPTION
Performance (using performance test in the code-base) went from ~1,390ms to ~350ms (~4x faster). Main points:

* filter generation + ifftshift is done in a simple RawKernel
* Pre-processing of data + post-processing done in Elementwise kernel each
* FFT2, filter, IFFT2 is done without for loop, over the whole stack of images
