### PR TITLE
Optimised _filtersinc3D_cupy of reconstruct_tomobar (>100x faster)

### DIFF
--- a/httomolib/recon/algorithm.py
+++ b/httomolib/recon/algorithm.py
@@ -24,6 +24,7 @@
 from typing import Optional
 
 import cupy as cp
+import cupyx
 import numpy as np
 import nvtx
 
@@ -105,8 +106,11 @@ def reconstruct_tomobar(
                                 device_projector = 'gpu',
                                 GPUdevice_index=gpu_id)    
         # ------------------------------------------------------- # 
-        data = _filtersinc3D_cupy(cp.swapaxes(data, 0, 1)) # filter the data on the GPU and keep the result there        
-        
+        data = _filtersinc3D_cupy(data) # filter the data on the GPU and keep the result there
+        # the Astra toolbox requires C-contiguous arrays, and swapaxes seems to return a sliced view which 
+        # is neither C nor F contiguous. 
+        # So we have to make it C-contiguous first
+        data = cp.ascontiguousarray(cp.swapaxes(data, 0, 1))
         reconstruction = Atools.backprojCuPy(data) # backproject the filtered data while keeping data on the GPU
         cp._default_memory_pool.free_all_blocks()
         # ------------------------------------------------------- #
@@ -114,6 +118,7 @@ def reconstruct_tomobar(
         raise ValueError("Unknown algorithm type, please specify FBP3D_device or FBP3D_host")
     return reconstruction
 
+@nvtx.annotate()
 def _filtersinc3D_cupy(projection3D):
     """applies a filter to 3D projection data
 
@@ -123,32 +128,111 @@ def _filtersinc3D_cupy(projection3D):
     Returns:
         ndarray: a CuPy array of filtered projection data.
     """
-    a = 1.1
-    [DetectorsLengthV, projectionsNum, DetectorsLengthH] = cp.shape(projection3D)
-    w = cp.linspace(-cp.pi,cp.pi-(2*cp.pi)/DetectorsLengthH, DetectorsLengthH,dtype='float32')
     
     # prepearing a ramp-like filter to apply to every projection
-    rn1 = cp.abs(2.0/a*cp.sin(a*w/2.0))
-    rn2 = cp.sin(a*w/2.0)
-    rd = (a*w)/2.0
-    rd_c = cp.zeros([1,DetectorsLengthH])
-    rd_c[0,:] = rd
-    r = rn1*(cp.dot(rn2, cp.linalg.pinv(rd_c)))**2
-    multiplier = (1.0/projectionsNum)
-    f = cp.fft.fftshift(r)
-    filter_2d = cp.zeros((DetectorsLengthV,DetectorsLengthH), dtype='float32') # 2d filter
-    filter_2d[0::,:] = f
+    filter_prep = cp.RawKernel(
+        r"""
+        #define MY_PI 3.1415926535897932384626433832795f
+
+        extern "C" __global__ 
+        void generate_filtersinc(float a, float* f, int n, float multiplier) {
+            int tid = threadIdx.x;    // using only one block
+
+            float dw = 2 * MY_PI / n;
+
+            extern __shared__ char smem_raw[];
+            float* smem = reinterpret_cast<float*>(smem_raw);
+
+            // from: cp.linalg.pinv(rd_c)
+            // pseudo-inverse of vector is x/sum(x**2),
+            // so we need to compute sum(x**2) in shared memory
+            float sum = 0.0;
+            for (int i = tid; i < n; i += blockDim.x) {
+                float w = -MY_PI  + i * dw;
+                float rn2 = a * w / 2.0f;
+                sum += rn2 * rn2;
+            }
+            
+            smem[tid] = sum;
+            __syncthreads();
+            int nt = blockDim.x;
+            int c = nt;
+            while (c > 1) {
+                int half = c / 2;
+                if (tid < half) {
+                    smem[tid] += smem[c - tid - 1];
+                }
+                __syncthreads();
+                c = c - half;
+            }
+            float sum_aw2_sqr = smem[0];
+
+            // cp.dot(rn2, cp.linalg.pinv(rd_c))**2
+            // now we can calclate the dot product, preparing summing in shared memory
+            float dot_partial = 0.0;
+            for (int i = tid; i < n; i += blockDim.x) {
+                float w = -MY_PI  + i * dw;
+                float rd = a*w/2.0f;
+                float rn2 = sin(rd);
+                
+                dot_partial += rn2 * rd / sum_aw2_sqr;
+            }
+                
+            // now reduce dot_partial to full dot-product result
+            smem[tid] = dot_partial;
+            __syncthreads();
+            c = nt;
+            while (c > 1) {
+                int half = c / 2;
+                if (tid < half) {
+                    smem[tid] += smem[c - tid - 1];
+                }
+                __syncthreads();
+                c = c - half;
+            }
+            float dotprod_sqr = smem[0] * smem[0];
+
+            // now compute actual result
+            for (int i = tid; i < n; i += blockDim.x) {
+                float w = -MY_PI  + i * dw;
+                float rd = a*w/2.0f;
+                float rn2 = sin(rd);
+                float rn1 = abs(2.0/a*rn2);
+                float r = rn1 * dotprod_sqr;
+
+                
+                // write to ifftshifted positions
+                int shift = n / 2;
+                int outidx = (i + shift) % n;
+
+                // apply multiplier here - which does FFT scaling too
+                f[outidx] = r * multiplier;
+            }
+        }
+        """, "generate_filtersinc"
+    )
+
+
+    # since the fft is complex-to-complex, it makes a copy of the real input array anyway,
+    # so we do that copy here explicitly, and then do everything in-place
+    projection3D = projection3D.astype(cp.complex64)
+    projection3D = cupyx.scipy.fft.fft2(projection3D, axes=(1, 2), overwrite_x=True, norm="backward")
     
-    filtered = cp.zeros(cp.shape(projection3D), dtype='float32') # convert to cupy array
-
-    for i in range(0,projectionsNum):
-        IMG = cp.fft.fft2(projection3D[:,i,:])
-        fimg = IMG*filter_2d
-        filtered[:,i,:] = cp.real(cp.fft.ifft2(fimg))
-
-    del projection3D
-    cp._default_memory_pool.free_all_blocks()
-    return multiplier*filtered
+    # generating the filter here so we can schedule/allocate while FFT is keeping the GPU busy
+    a = 1.1
+    (projectionsNum, DetectorsLengthV, DetectorsLengthH) = cp.shape(projection3D)
+    f = cp.empty((1,1,DetectorsLengthH), dtype=np.float32)
+    bx = 256
+    # because FFT is linear, we can apply the FFT scaling + multiplier in the filter
+    multiplier = 1.0/projectionsNum/DetectorsLengthV/DetectorsLengthH
+    filter_prep(grid=(1, 1, 1), block=(bx, 1, 1), 
+                args=(cp.float32(a), f, np.int32(DetectorsLengthH), np.float32(multiplier)),
+                shared_mem=bx*4)
+    # actual filtering
+    projection3D *= f
+    
+    # avoid normalising here - we have included that in the filter
+    return cp.real(cupyx.scipy.fft.ifft2(projection3D, axes=(1, 2), overwrite_x=True, norm="forward"))
 ## %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 
 


### PR DESCRIPTION
This optimises `reconstruct_tomobar` as far as possible, without touching the astra toolbox call. In particular:

- the FFT2 is done on the whole batch without a for loop
- the filter generation is done in a custom kernel to avoid temporaries and lots of tiny kernel calls
- the axis swapping is done after the filtering, to ensure continuous data for the FFT
- FFT scaling is multiplied into the filter itself, and there's no need to scale after FFT

The performance of `_filtersinc3D_cupy` improves from ~420ms to less than 4ms - greater, see screenshots before/after.

Note: Though we compared the filter visually, there is no real test for this function. So we can't be 100% sure if the result is correct. We suggest that you create a test for it separately, and once it's there, we'll merge it into this branch to confirm.

Before: 
![image](https://user-images.githubusercontent.com/121804917/217527782-feb3e718-8c5f-4875-bc27-789395137bba.png)

After:
![image](https://user-images.githubusercontent.com/121804917/217528183-8e9adc30-5321-43b0-9caa-93c8fb312a50.png)
