### PR TITLE
Optimised find_center_vo_cupy

### DIFF
--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -21,6 +21,7 @@
 # ---------------------------------------------------------------------------
 """Modules for finding the axis of rotation"""
 
+import math
 from typing import Optional
 
 import cupy as cp
@@ -98,13 +99,15 @@ def _find_center_vo_gpu(sino, ind, smin, smax, srad, step, ratio, drop):
     else:
         _sino = sino[:, ind, :]
 
-    _sino_cs = gaussian_filter(_sino, (3, 1), mode="reflect")
-    _sino_fs = gaussian_filter(_sino, (2, 2), mode="reflect")
-
+    with nvtx.annotate("gaussian_filter_1", color="green"):
+        _sino_cs = gaussian_filter(_sino, (3, 1), mode="reflect")
+    with nvtx.annotate("gaussian_filter_2", color="green"):
+        _sino_fs = gaussian_filter(_sino, (2, 2), mode="reflect")
+    
     if _sino.shape[0] * _sino.shape[1] > 4e6:
         # data is large, so downsample it before performing search for
         # centre of rotation
-        _sino_coarse = _downsample(cp.expand_dims(_sino_cs, 1), 2, 2)[:, 0, :]
+        _sino_coarse = _downsample(_sino_cs, 2, 1)
         init_cen = _search_coarse(_sino_coarse, smin / 4.0, smax / 4.0, ratio, drop)
         fine_cen = _search_fine(_sino_fs, srad, step, init_cen * 4.0, ratio, drop)
     else:
@@ -114,30 +117,25 @@ def _find_center_vo_gpu(sino, ind, smin, smax, srad, step, ratio, drop):
     return fine_cen.astype(cp.float32)
 
 
+@nvtx.annotate()
 def _search_coarse(sino, smin, smax, ratio, drop):
     (nrow, ncol) = sino.shape
+    flip_sino = cp.ascontiguousarray(cp.fliplr(sino))
+    comp_sino = cp.ascontiguousarray(cp.flipud(sino))
+    mask = _create_mask(2 * nrow, ncol, 0.5 * ratio * ncol, drop)
+
     cen_fliplr = (ncol - 1.0) / 2.0
-    smin_clip_val = cp.clip(cp.asarray([smin + cen_fliplr]), 0, ncol - 1)
-    smin = cp.float_(smin_clip_val - cen_fliplr)
-    smax_clip_val = cp.clip(cp.asarray([smax + cen_fliplr]), 0, ncol - 1)
-    smax = cp.float_(smax_clip_val - cen_fliplr)
+    smin_clip_val = max(min(smin + cen_fliplr, ncol - 1), 0)
+    smin = smin_clip_val - cen_fliplr
+    smax_clip_val = max(min(smax + cen_fliplr, ncol - 1), 0)
+    smax = smax_clip_val - cen_fliplr
     start_cor = ncol // 2 + smin
     stop_cor = ncol // 2 + smax
-    flip_sino = cp.fliplr(sino)
-    comp_sino = cp.flipud(sino)
-    list_cor = cp.arange(start_cor, stop_cor + 0.5, 0.5)
-    list_metric = cp.zeros(len(list_cor), dtype=cp.float32)
-    mask = _create_mask(2 * nrow, ncol, 0.5 * ratio * ncol, drop)
+    list_cor = cp.arange(start_cor, stop_cor + 0.5, 0.5, dtype=cp.float32)
     list_shift = 2.0 * (list_cor - cen_fliplr)
-    list_metric = cp.zeros(list_shift.shape, dtype="float32")
-    # TODO: for now, use a for loop to calculate the metric for each shift, but
-    # this should be optimised in the future, as it's a computationally
-    # expensive part of the algorithm
-    for i in range(list_shift.shape[0]):
-        list_metric[i] = _calculate_metric(
-            list_shift[i], sino, flip_sino, comp_sino, mask
-        )
-
+    list_metric = cp.empty(list_shift.shape, dtype=cp.float32)
+    _calculate_metric(list_shift, sino, flip_sino, comp_sino, mask, list_metric)
+    
     minpos = cp.argmin(list_metric)
     if minpos == 0:
         print("WARNING!!!Global minimum is out of searching range")
@@ -149,28 +147,23 @@ def _search_coarse(sino, smin, smax, ratio, drop):
     return cor
 
 
+@nvtx.annotate()
 def _search_fine(sino, srad, step, init_cen, ratio, drop):
     (nrow, ncol) = sino.shape
-    cen_fliplr = (ncol - 1.0) / 2.0
-    srad_clip_val = cp.clip(cp.asarray([cp.abs(srad)]), 1.0, ncol / 4.0)
-    srad = cp.float_(srad_clip_val)
-    step_clip_val = cp.clip(cp.asarray([cp.abs(step)]), 0.1, srad)
-    step = cp.float_(step_clip_val)
-    init_cen_clip_val = cp.clip(cp.asarray([init_cen]), srad, ncol - srad - 1)
-    init_cen = cp.float_(init_cen_clip_val)
-    list_cor = init_cen + cp.arange(-srad, srad + step, step)
-    flip_sino = cp.fliplr(sino)
-    comp_sino = cp.flipud(sino)
+
+    flip_sino = cp.ascontiguousarray(cp.fliplr(sino))
+    comp_sino = cp.ascontiguousarray(cp.flipud(sino))
     mask = _create_mask(2 * nrow, ncol, 0.5 * ratio * ncol, drop)
+    
+    cen_fliplr = (ncol - 1.0) / 2.0
+    srad = max(min(abs(float(srad)), ncol/4.0), 1.0)
+    step = max(min(abs(step), srad), 0.1)
+    init_cen = max(min(init_cen, ncol - srad - 1), srad)
+    list_cor = init_cen + cp.arange(-srad, srad + step, step, dtype=np.float32)
     list_shift = 2.0 * (list_cor - cen_fliplr)
-    list_metric = cp.zeros(list_shift.shape, dtype="float32")
-    # TODO: for now, use a for loop to calculate the metric for each shift, but
-    # this should be optimised in the future, as it's a computationally
-    # expensive part of the algorithm
-    for i in range(list_shift.shape[0]):
-        list_metric[i] = _calculate_metric(
-            list_shift[i], sino, flip_sino, comp_sino, mask
-        )
+    list_metric = cp.empty(list_shift.shape, dtype="float32")
+    
+    _calculate_metric(list_shift, sino, flip_sino, comp_sino, mask, out=list_metric)
     cor = list_cor[cp.argmin(list_metric)]
     return cor
 
@@ -180,60 +173,77 @@ GENERATE_MASK_KERNEL = cp.RawKernel(
 extern "C" __global__
 void generate_mask(const int ncol, const int nrow, const int cen_col,
                     const int cen_row, const float du, const float dv,
-                    const float radius, unsigned short* mask) {
+                    const float radius, const float drop, unsigned short* mask) {
     int i = blockDim.x * blockIdx.x + threadIdx.x;
     int j = blockDim.y * blockIdx.y + threadIdx.y;
-    int tid = (j * ncol) + i;
-    int pos, temp;
-    int pos1, pos2;
-    if (tid < ncol * nrow) {
-        pos = __float2int_ru(((j - cen_row) * dv / radius) / du);
-        pos1 = -pos + cen_col;
-        pos2 = pos + cen_col;
-        if (pos1 > pos2) {
-            temp = pos1;
-            pos1 = pos2;
-            pos2 = temp;
-            if (pos1 > ncol - 1) {
-                pos1 = ncol -1;
-            }
-            if (pos2 < 0) {
-                pos2 = 0;
-            }
+    
+    if (j >= nrow || i >= ncol)
+        return;
+    
+    int pos = __float2int_ru(((j - cen_row) * dv / radius) / du);
+    int pos1 = -pos + cen_col;
+    int pos2 = pos + cen_col;
+
+    if (pos1 > pos2) {
+        int temp = pos1;
+        pos1 = pos2;
+        pos2 = temp;
+        if (pos1 >= ncol) {
+            pos1 = ncol -1;
         }
-        else{
-            if (pos1 < 0) {
-                pos1 = 0;
-            }
-            if (pos2 > ncol - 1) {
-                pos2 = ncol -1;
-            }
-        }
-        if (pos1 <= i && i <= pos2) {
-            mask[tid] = 1;
+        if (pos2 < 0) {
+            pos2 = 0;
         }
     }
+    else {
+        if (pos1 < 0) {
+            pos1 = 0;
+        }
+        if (pos2 >= ncol) {
+            pos2 = ncol -1;
+        }
+    }
+
+    short outval = (pos1 <= i && i <= pos2) ? 1 : 0;
+
+    // mask[cen_row - drop: cen_row + drop + 1, :] = 0
+    if (j >= cen_row - drop && j <= cen_row + drop) {
+        outval = 0;
+    }
+    // mask[:, cen_col - 1: cen_col + 2] = 0
+    if (i >= cen_col - 1 && i <= cen_col + 1) {
+        outval = 0;
+    }
+    
+    // write to ifft-shifted positions
+    int ishift = (ncol + 1) / 2;
+    int jshift = (nrow + 1) / 2;
+    int outi = (i + ishift) % ncol;
+    int outj = (j + jshift) % nrow;
+
+    mask[outj * ncol + outi] = outval;
 }
 """,
     "generate_mask",
 )
 
 
+@nvtx.annotate()
 def _create_mask(nrow, ncol, radius, drop):
     du = 1.0 / ncol
-    dv = (nrow - 1.0) / (nrow * 2.0 * cp.pi)
-    cen_row = int(cp.ceil(nrow / 2.0) - 1)
-    cen_col = int(cp.ceil(ncol / 2.0) - 1)
-    drop = cp.min(cp.asarray([drop, int(cp.ceil(0.05 * nrow))]))
+    dv = (nrow - 1.0) / (nrow * 2.0 * np.pi)
+    cen_row = int(math.ceil(nrow / 2.0) - 1)
+    cen_col = int(math.ceil(ncol / 2.0) - 1)
+    drop = min([drop, int(math.ceil(0.05 * nrow))])
 
 
-    block_x = 8
+    block_x = 16
     block_y = 8
     block_dims = (block_x, block_y)
-    grid_x = int(cp.ceil(ncol / block_x))
-    grid_y = int(cp.ceil(nrow / block_y))
+    grid_x = (ncol + block_x - 1) // block_x
+    grid_y = (nrow  + block_y - 1) // block_y
     grid_dims = (grid_x, grid_y)
-    mask = cp.zeros((nrow, ncol), dtype="uint16")
+    mask = cp.empty((nrow, ncol), dtype="uint16")
     params = (
         ncol,
         nrow,
@@ -242,45 +252,119 @@ def _create_mask(nrow, ncol, radius, drop):
         cp.float32(du),
         cp.float32(dv),
         cp.float32(radius),
+        cp.float32(drop),
         mask,
     )
     GENERATE_MASK_KERNEL(grid_dims, block_dims, params)
-    mask[cen_row - drop: cen_row + drop + 1, :] = 0
-    mask[:, cen_col - 1: cen_col + 2] = 0
     return mask
 
 
-def _calculate_metric(shift_col, sino1, sino2, sino3, mask):
-    # TODO: currently this function is passed one element at a time from the
-    # caller's shift_col array inside a for loop; this is inefficient, and this
-    # function should be considered to be rewritten as a kernel function for
-    # better performance
-    if cp.abs(shift_col - cp.floor(shift_col)) == 0.0:
-        shift_col = int(shift_col)
-        sino_shift = cp.roll(sino2, shift_col, axis=1)
-        if shift_col >= 0:
-            sino_shift[:, :shift_col] = sino3[:, :shift_col]
-        else:
-            sino_shift[:, shift_col:] = sino3[:, shift_col:]
-        mat = cp.vstack((sino1, sino_shift))
+def round_up(x: float) -> int:
+    if x >= 0.0:
+        return int(math.ceil(x))
     else:
-        sino_shift = shift(sino2, (0, shift_col), order=3, prefilter=True)
-        if shift_col >= 0:
-            shift_int = int(cp.ceil(shift_col))
-            sino_shift[:, :shift_int] = sino3[:, :shift_int]
-        else:
-            shift_int = int(cp.floor(shift_col))
-            sino_shift[:, shift_int:] = sino3[:, shift_int:]
-        mat = cp.vstack((sino1, sino_shift))
-    metric = cp.mean(cp.abs(cp.fft.fftshift(cp.fft.fft2(mat)) * mask))
+        return int(math.floor(x))
 
-    return cp.asarray([metric], dtype="float32")
+
+@nvtx.annotate()
+def _calculate_metric(list_shift, sino1, sino2, sino3, mask, out):
+    # this tries to simplify - if shift_col is integer, no need to spline interpolate
+    assert list_shift.dtype == cp.float32, "shifts must be single precision floats"
+    assert sino1.dtype == cp.float32, "sino1 must be float32"
+    assert sino2.dtype == cp.float32, "sino1 must be float32"
+    assert sino3.dtype == cp.float32, "sino1 must be float32"
+    assert out.dtype == cp.float32, "sino1 must be float32"
+    assert sino2.flags['C_CONTIGUOUS'], "sino2 must be C-contiguous"
+    assert sino3.flags['C_CONTIGUOUS'], "sino3 must be C-contiguous"
+    assert list_shift.flags['C_CONTIGUOUS'], "list_shift must be C-contiguous"
+    nshifts = list_shift.shape[0]
+    na1 = sino1.shape[0]
+    na2 = sino2.shape[0]
+    mat = cp.empty((nshifts, na1+na2, sino2.shape[1]), dtype=cp.float32)
+    
+    
+    # first, handle the integer shifts without spline in a raw kernel, 
+    # and shift in the sino3 one accordingly
+    shift_whole_shifts = cp.RawKernel(r"""
+        #include <cupy/complex.cuh>
+
+        extern "C" __global__
+        void shift_whole_shifts(const float* sino2, const float* sino3, 
+                                const float* __restrict__ list_shift,
+                                float* mat, int nx, int nymat) {
+           int xid = threadIdx.x + blockIdx.x * blockDim.x;
+           int yid = blockIdx.y;
+           int zid = blockIdx.z;
+           int ny = gridDim.y;
+           
+           if (xid >= nx) return;
+           
+           float shift_col = list_shift[zid];
+           float int_part = 0.0;
+           float frac_part = modf(shift_col, &int_part);
+           if (abs(frac_part) > 1e-5f) {
+                // we have a floating point shift, so we only roll in 
+                // sino3, but we leave the rest for later using scipy
+                int shift_int = shift_col >= 0.0 ? int(ceil(shift_col)) : int(floor(shift_col));
+                if (shift_int >= 0 && xid < shift_int) {
+                   mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+                } 
+                if (shift_int < 0 && xid >= nx+shift_int) {
+                   mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+                }
+           } else {
+                // we have an integer shift, so we can roll in directly
+                // by indexing
+                int shift_int = int(shift_col);
+                if (shift_int >= 0) {
+                    if (xid >= shift_int) {
+                        mat[zid * nymat * nx + yid * nx + xid] = sino2[yid * nx + xid-shift_int];
+                    } else {
+                        mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+                    }
+                } else {
+                    if (xid < nx+shift_int) {
+                        mat[zid * nymat * nx + yid * nx + xid] = sino2[yid * nx + xid-shift_int];
+                    } else {
+                        mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+                    }
+                }
+           }
+        }
+    """, name="shift_whole_shifts")
+
+    bx = 128
+    gx = (sino3.shape[1] + bx - 1) // bx
+    shift_whole_shifts(grid=(gx, na2, list_shift.shape[0]),
+                       block=(bx, 1, 1),
+                       args=(sino2, sino3, list_shift, mat[:,na1:,:], sino3.shape[1], na1+na2))
+    
+    # now we can only look at the spline shifting, the rest is done
+    list_shift_host = cp.asnumpy(list_shift)
+    for i in range(list_shift_host.shape[0]):
+        shift_col = float(list_shift_host[i])
+        if not shift_col.is_integer():
+            shifted = shift(sino2, (0, shift_col), order=3, prefilter=True)
+            shift_int = round_up(shift_col)
+            if shift_int >= 0:
+                mat[i, na1:, shift_int:] = shifted[:, shift_int:]
+            else:
+                mat[i, na1:, :shift_int] = shifted[:, :shift_int]
+
+        
+    # stack and transform
+    mat[:,:na1,:] = sino1
+    cp.abs(cp.fft.fft2(mat, axes=(1,2)), out=mat)
+    mat *= mask
+    cp.mean(mat, axis=(1,2), out=out)
+
+
 
 
 DOWNSAMPLE_SINO_KERNEL = cp.RawKernel(
     r"""
     extern "C" __global__
-    void downsample_sino(float* sino, int dx, int dy, int dz, int level,
+    void downsample_sino(float* sino, int dx, int dz, int level,
                          float* out) {
         // use shared memory to store the values used to "merge" columns of the
         // sinogram in the downsampling process
@@ -290,8 +374,7 @@ DOWNSAMPLE_SINO_KERNEL = cp.RawKernel(
         j = 0;
         k = blockDim.y * blockIdx.y + threadIdx.y;
         orig_ind = (k * dz) + i;
-        binsize = __float2uint_rd(
-            powf(__uint2float_rd(2), level));
+        binsize = 1 << level;
         unsigned int dz_downsampled = __float2uint_rd(
             fdividef(__uint2float_rd(dz), __uint2float_rd(binsize)));
         unsigned int i_downsampled = __float2uint_rd(
@@ -322,26 +405,29 @@ DOWNSAMPLE_SINO_KERNEL = cp.RawKernel(
 )
 
 
+@nvtx.annotate()
 def _downsample(sino, level, axis):
-    sino = cp.asarray(sino, dtype="float32")
-    dx, dy, dz = sino.shape
+    assert sino.dtype == cp.float32, "single precision floating point input required"
+    assert sino.flags['C_CONTIGUOUS'], "list_shift must be C-contiguous"
+
+    dx, dz = sino.shape
     # Determine the new size, dim, of the downsampled dimension
-    dim = int(sino.shape[axis] / cp.power(2, level))
-    shape = [dx, dy, dz]
+    dim = int(sino.shape[axis] / math.pow(2, level))
+    shape = [dx, dz]
     shape[axis] = dim
-    downsampled_data = cp.zeros(shape, dtype="float32")
+    downsampled_data = cp.empty(shape, dtype="float32")
 
     block_x = 8
     block_y = 8
     block_dims = (block_x, block_y)
-    grid_x = int(cp.ceil(sino.shape[2] / block_x))
-    grid_y = int(cp.ceil(sino.shape[0] / block_y))
+    grid_x = (sino.shape[1] + block_x - 1) // block_x
+    grid_y = (sino.shape[0] + block_y - 1) // block_y
     grid_dims = (grid_x, grid_y)
     # 8x8 thread-block, which means 16 "lots" of columns to downsample per
     # thread-block; 4 bytes per float, so allocate 16*6 = 64 bytes of shared
     # memeory per thread-block
     shared_mem_bytes = 64
-    params = (sino, dx, dy, dz, level, downsampled_data)
+    params = (sino, dx, dz, level, downsampled_data)
     DOWNSAMPLE_SINO_KERNEL(grid_dims, block_dims, params, shared_mem=shared_mem_bytes)
     return downsampled_data
 


### PR DESCRIPTION
This optimises the function `find_center_vo_cupy` for the GPU, as far as it goes without changing the algorithm / logic involved. 

### Performance Improvement: 255ms -> 194ms (1.31x)

(This was measured on V100 using the performance test that is part of this PR.)

### Remaining Bottlenecks

The key bottleneck however are the spline shifts for sub-pixel shifting - they dominate the overall time by far (ignoring the FFT), especially after these optimisations. We get the following picture for the kernel percentages:

| Function | Percent GPU before | Percent GPU after |
|---|---:|---:|
| FFT | 44.3% | 46.4% |
| Spline Shift | 29.8% | 33.6% |
| all other kernels combined | 20.4% | 19.2% |
| Memory operations | 5.5% | 0.8% |

(Note that the FFT dimensions are not powers of 2 - this causes the long FFT time. Also note that a big part of the optimisation was reducing the number of kernel calls and hereby reducing gaps where the GPU is idle.)

### Details of Changes

- small operations such as ceil, div, abs, of scalars are computed on the CPU instead of launching kernels
- other small operations where joined on the GPU
- axis extensions and copies of data are avoided
- a single RawKernel does:
   - integer shifts of the input data for all lines where the shift is integer
   - inserts the `sino3` array into the part which was shifted out
 - then the scipy ndimage shift function (using order 3 splines with prefiltering) is only called for the rows fractional shifts, in a loop
 - the FFT, masking, and mean calculation is done once for all possible shifts (outside of the loop)
 - the downsample and mask generation kernels have been optimised further

