### PR TITLE
Unified numpy/cupy test infrastructure

### DIFF
--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -57,7 +57,7 @@ def find_center_vo_cupy(
     data : ndarray
         3D tomographic data or a 2D sinogram as a CuPy array.
     ind : int, optional
-        Index of the slice to be used for reconstruction.
+        Index of the slice to be used to estimate the CoR.
     smin : int, optional
         Coarse search radius. Reference to the horizontal center of
         the sinogram.
@@ -82,21 +82,21 @@ def find_center_vo_cupy(
     return _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop)
 
 
-def _find_center_vo_gpu(sino, ind, smin, smax, srad, step, ratio, drop):
-    if sino.ndim == 2:
-        sino = cp.expand_dims(sino, 1)
+def _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop):
+    if data.ndim == 2:
+        data = cp.expand_dims(data, 1)
         ind = 0
 
-    height = sino.shape[1]
+    height = data.shape[1]
 
     if ind is None:
         ind = height // 2
         if height > 10:
-            _sino = cp.mean(sino[:, ind - 5: ind + 5, :], axis=1)
+            _sino = cp.mean(data[:, ind - 5: ind + 5, :], axis=1)
         else:
-            _sino = sino[:, ind, :]
+            _sino = data[:, ind, :]
     else:
-        _sino = sino[:, ind, :]
+        _sino = data[:, ind, :]
 
     _sino_cs = gaussian_filter(_sino, (3, 1), mode="reflect")
     _sino_fs = gaussian_filter(_sino, (2, 2), mode="reflect")
@@ -349,7 +349,8 @@ def _downsample(sino, level, axis):
 #--- Center of rotation (COR) estimation method ---#
 @nvtx.annotate()
 def find_center_360(
-    sino_360: np.ndarray,
+    data: np.ndarray,
+    ind: int = None,
     win_width: int = 10,
     side: set = None,
     denoise: bool = True,
@@ -362,8 +363,10 @@ def find_center_360(
 
     Parameters
     ----------
-    sino_360 : ndarray
-        2D array, a 360-degree sinogram.
+    data : ndarray
+        3D tomographic data as a CuPy array.
+    ind : int, optional
+        Index of the slice to be used for estimate the CoR and the overlap.        
     win_width : int, optional
         Window width used for finding the overlap area.
     side : {None, 0, 1}, optional
@@ -394,13 +397,19 @@ def find_center_360(
     ----------
     [1] : https://doi.org/10.1364/OE.418448
     """
-    if sino_360.ndim != 2:
-        raise ValueError("360-degree sinogram must be a 2D array.")
-
-    (nrow, ncol) = sino_360.shape
+    if data.ndim != 3:
+        raise ValueError("A 3D array must be provided")
+    
+    # this method works with a 360-degree sinogram.
+    if ind is None:
+        _sino = data[:, 0, :]        
+    else:
+        _sino = data[:, ind, :]  
+    
+    (nrow, ncol) = _sino.shape
     nrow_180 = nrow // 2 + 1
-    sino_top = sino_360[0:nrow_180, :]
-    sino_bot = np.fliplr(sino_360[-nrow_180:, :])
+    sino_top = _sino[0:nrow_180, :]
+    sino_bot = np.fliplr(_sino[-nrow_180:, :])
     (overlap, side, overlap_position) = _find_overlap(
         sino_top, sino_bot, win_width, side, denoise, norm, use_overlap)
     if side == 0:

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -400,6 +400,10 @@ def find_center_360(
     if data.ndim != 3:
         raise ValueError("A 3D array must be provided")
     
+    xp = cp.get_array_module(data)
+    if xp.__name__ != "numpy":
+        raise NotImplementedError("Cuda implementation not implemented")
+
     # this method works with a 360-degree sinogram.
     if ind is None:
         _sino = data[:, 0, :]        
@@ -462,22 +466,22 @@ def _find_overlap(mat1, mat2, win_width, side=None, denoise=True, norm=False,
     win_width = np.int16(np.clip(win_width, 6, min(ncol1, ncol2) // 2))
 
     if side == 1:
-        (list_metric, offset) = _search_overlap(mat1, mat2, win_width, side,
-                                               denoise, norm, use_overlap)
+        (list_metric, offset) = _search_overlap(mat1, mat2, win_width, side=side,
+                                               denoise=denoise, norm=norm, use_overlap=use_overlap)
         overlap_position = _calculate_curvature(list_metric)[1]
         overlap_position += offset
         overlap = ncol1 - overlap_position + win_width // 2
     elif side == 0:
-        (list_metric, offset) = _search_overlap(mat1, mat2, win_width, side,
-                                               denoise, norm, use_overlap)
+        (list_metric, offset) = _search_overlap(mat1, mat2, win_width, side=side,
+                                               denoise=denoise, norm=norm, use_overlap=use_overlap)
         overlap_position = _calculate_curvature(list_metric)[1]
         overlap_position += offset
         overlap = overlap_position + win_width // 2
     else:
-        (list_metric1, offset1) = _search_overlap(mat1, mat2, win_width, 1,
-                                                 norm, denoise, use_overlap)
-        (list_metric2, offset2) = _search_overlap(mat1, mat2, win_width, 0,
-                                                 norm, denoise, use_overlap)
+        (list_metric1, offset1) = _search_overlap(mat1, mat2, win_width, side=1,
+                                                 denoise=denoise, norm=norm, use_overlap=use_overlap)
+        (list_metric2, offset2) = _search_overlap(mat1, mat2, win_width, side=0,
+                                                 denoise=denoise, norm=norm, use_overlap=use_overlap)
 
         (curvature1, overlap_position1) = _calculate_curvature(list_metric1)
         overlap_position1 += offset1

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -364,7 +364,7 @@ def find_center_360(
     Parameters
     ----------
     data : ndarray
-        3D tomographic data as a CuPy array.
+        3D tomographic data as a Numpy array.
     ind : int, optional
         Index of the slice to be used for estimate the CoR and the overlap.        
     win_width : int, optional
@@ -642,3 +642,60 @@ def _correlation_metric(mat1, mat2):
     """
     return np.abs(
         1.0 - stats.pearsonr(mat1.flatten('F'), mat2.flatten('F'))[0])
+
+
+#--- Center of rotation (COR) estimation method ---#
+@nvtx.annotate()
+def find_center_360_cupy(
+    data: cp.ndarray,
+    ind: int = None,
+    win_width: int = 10,
+    side: set = None,
+    denoise: bool = True,
+    norm: bool = False,
+    use_overlap: bool = False
+) -> tuple[float, float, int, float]:
+    """
+    Find the center-of-rotation (COR) in a 360-degree scan with offset COR use
+    the method presented in Ref. [1] by Nghia Vo.
+
+    Parameters
+    ----------
+    data : ndarray
+        3D tomographic data as a CuPy array.
+    ind : int, optional
+        Index of the slice to be used for estimate the CoR and the overlap.        
+    win_width : int, optional
+        Window width used for finding the overlap area.
+    side : {None, 0, 1}, optional
+        Overlap size. Only there options: None, 0, or 1. "None" corresponds
+        to fully automated determination. "0" corresponds to the left side.
+        "1" corresponds to the right side.
+    denoise : bool, optional
+        Apply the Gaussian filter if True.
+    norm : bool, optional
+        Apply the normalisation if True.
+    use_overlap : bool, optional
+        Use the combination of images in the overlap area for calculating
+        correlation coefficients if True.
+
+    Returns
+    -------
+    cor : float
+        Center-of-rotation.
+    overlap : float
+        Width of the overlap area between two halves of the sinogram.
+    side : int
+        Overlap side between two halves of the sinogram.
+    overlap_position : float
+        Position of the window in the first image giving the best
+        correlation metric.
+
+    References
+    ----------
+    [1] : https://doi.org/10.1364/OE.418448
+    """
+    if data.ndim != 3:
+        raise ValueError("A 3D array must be provided")
+
+    raise NotImplementedError("CUDA implementation still pending")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,34 @@ def pytest_collection_modifyitems(config, items):
             if "perf" in item.keywords:
                 item.add_marker(skip_perf)
 
+@pytest.fixture
+def have_gpu_noskip():
+    """Returns true or false depending if a GPU is available"""
+    try:
+        import cupy
+        return True
+    except ImportError:
+        return False
+
+
+@cp.testing.gpu
+@pytest.fixture
+def have_gpu(have_gpu_noskip):
+    """Skips the test if GPU is not available"""
+    if not have_gpu_noskip:
+        pytest.skip()
+    return have_gpu_noskip
+
+
+@pytest.fixture(params=[pytest.param(True, marks=pytest.mark.gpu), False], ids=["cupy", "numpy"])
+def gpu(request, have_gpu_noskip):
+    """Parametrized fixture to run tests for both cupy and numpy,
+       skipping the cupy one if no GPU is available
+    """
+    if request.param and not have_gpu_noskip:
+        pytest.skip()
+    return request.param
+
 
 @pytest.fixture(scope="session")
 def test_data_path():

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -1,10 +1,10 @@
 import time
 import cupy as cp
-import nvtx
+from cupy.cuda import nvtx
 import numpy as np
 import pytest
 from httomolib.prep.normalize import normalize_cupy
-from httomolib.recon.rotation import find_center_360, find_center_vo_cupy, find_center_360_cupy
+from httomolib.recon.rotation import find_center_360, find_center_vo_cupy
 from numpy.testing import assert_allclose
 
 
@@ -32,12 +32,10 @@ def test_find_center_vo_cupy_ones(ensure_clean_memory):
 
 
 def test_find_center_360_ones(gpu):
-    mat = np.ones(shape=(100, 100, 100))
-    if gpu:
-        (cor, overlap, side, overlap_position) = find_center_360_cupy(cp.asarray(mat))
-    else:
-        (cor, overlap, side, overlap_position) = find_center_360(mat)
+    xp = cp if gpu else np
+    mat = xp.ones(shape=(100, 100, 100), dtype=xp.float32)
     
+    (cor, overlap, side, overlap_position) = find_center_360(mat)
 
     assert_allclose(cor, 5.0)
     assert_allclose(overlap, 12.0)
@@ -48,10 +46,8 @@ def test_find_center_360_ones(gpu):
 
 def test_find_center_360_data(host_data, gpu):
     eps = 1e-5
-    if gpu:
-        (cor, overlap, side, overlap_pos) = find_center_360_cupy(cp.asarray(host_data))
-    else:
-        (cor, overlap, side, overlap_pos) = find_center_360(host_data)
+    data = cp.asarray(host_data) if gpu else host_data
+    (cor, overlap, side, overlap_pos) = find_center_360(data, norm=True, denoise=False)
     
     assert_allclose(cor, 132.45317, rtol=eps)
     assert_allclose(overlap, 53.093666, rtol=eps)
@@ -64,70 +60,60 @@ def test_find_center_360_data(host_data, gpu):
 
 
 @cp.testing.gpu
-def test_find_center_360_unity(ensure_clean_memory, have_gpu):
+@pytest.mark.parametrize("norm", [False, True], ids=["no_normalise", "normalise"])
+@pytest.mark.parametrize("overlap", [False, True], ids=["no_overlap", "overlap"])
+@pytest.mark.parametrize("denoise", [False, True], ids=["no_denoise", "denoise"])
+@pytest.mark.parametrize("side", [1, 0])
+@cp.testing.numpy_cupy_allclose(rtol=1e-5)
+def test_find_center_360_unity(ensure_clean_memory, xp, norm, overlap, denoise, side):
     eps = 1e-5
 
-    host_data = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
-    data = cp.asarray(host_data)
+    # because it's random, we explicitly seed and use numpy only, to match the data
+    np.random.seed(12345)
+    data = np.random.random_sample(size=(128, 1, 512)).astype(np.float32) * 2.0 + 0.001
+    data = xp.asarray(data)
+    
+    (cor, overlap, side, overlap_pos) = find_center_360(data, use_overlap=overlap, 
+                                                        norm=norm, denoise=denoise, 
+                                                        side=side)
 
-    (cor, overlap, side, overlap_pos) = find_center_360(host_data)
-    (cor_gpu, overlap_gpu, side_gpu, overlap_pos_gpu) = find_center_360_cupy(data)
-
-    np.testing.assert_allclose(cor, cor_gpu, rtol=eps)
-    np.testing.assert_allclose(overlap, overlap_gpu, rtol=eps)
-    np.testing.assert_allclose(side, side_gpu, rtol=eps)
-    np.testing.assert_allclose(overlap_pos, overlap_pos_gpu, rtol=eps)
+    return xp.asarray([cor, overlap, side, overlap_pos])
+    
 
 
 @pytest.mark.perf
-def test_find_center_360_performance(gpu):
-    host_data = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
+def test_find_center_360_performance(gpu, ensure_clean_memory):
+    xp = cp if gpu else np
+    data = xp.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
 
-    if gpu:
-        data = cp.asarray(host_data)
-        # cold run
-        find_center_360_cupy(data)
+    # cold run
+    find_center_360(data, use_overlap=True, norm=True, denoise=True)
 
-        dev = cp.cuda.Device()
-        dev.synchronize()
+    dev = cp.cuda.Device()
+    dev.synchronize()
 
-        start = time.perf_counter_ns()
-        nvtx.RangePush("Core")
-        for _ in range(10):
-            # have to take copy, as data is modified in-place
-            find_center_360_cupy(data)
-        nvtx.RangePop()
-        dev.synchronize()
-        
-        duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
-    else:
-        # cold run
-        find_center_360(host_data)
-
-        start = time.perf_counter_ns()
-        for _ in range(10):
-            # have to take copy, as data is modified in-place
-            find_center_360(host_data)
-        
-        duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
+    start = time.perf_counter_ns()
+    nvtx.RangePush("Core")
+    for _ in range(10):
+        # have to take copy, as data is modified in-place
+        find_center_360(data, use_overlap=True, norm=True, denoise=True)
+    nvtx.RangePop()
+    dev.synchronize()
     
+    duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
     
     assert "performance in ms" == duration_ms
 
 
 
 def test_find_center_360_1D_raises(host_data, gpu):
+    data = cp.asarray(host_data) if gpu else host_data
+    xp = cp if gpu else np
+    
     #: 360-degree sinogram must be a 3d array
-
     with pytest.raises(ValueError):
-        if gpu:
-            find_center_360_cupy(cp.asarray(host_data[:, 10, :]))
-        else:
-            find_center_360(host_data[:, 10, :])
+        find_center_360(data[:, 10, :])
     
     with pytest.raises(ValueError):
-        if gpu:
-            find_center_360_cupy(cp.ones(10))
-        else:
-            find_center_360(np.ones(10))
+        find_center_360(xp.ones(10))
         

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -1,8 +1,10 @@
+import time
 import cupy as cp
+import nvtx
 import numpy as np
 import pytest
 from httomolib.prep.normalize import normalize_cupy
-from httomolib.recon.rotation import find_center_360, find_center_vo_cupy
+from httomolib.recon.rotation import find_center_360, find_center_vo_cupy, find_center_360_cupy
 from numpy.testing import assert_allclose
 
 
@@ -29,9 +31,13 @@ def test_find_center_vo_cupy_ones(ensure_clean_memory):
     mat = None #: free up GPU memory
 
 
-def test_find_center_360_ones():
+def test_find_center_360_ones(gpu):
     mat = np.ones(shape=(100, 100, 100))
-    (cor, overlap, side, overlap_position) = find_center_360(mat)
+    if gpu:
+        (cor, overlap, side, overlap_position) = find_center_360_cupy(cp.asarray(mat))
+    else:
+        (cor, overlap, side, overlap_position) = find_center_360(mat)
+    
 
     assert_allclose(cor, 5.0)
     assert_allclose(overlap, 12.0)
@@ -39,9 +45,14 @@ def test_find_center_360_ones():
     assert_allclose(overlap_position, 7.0)
 
 
-def test_find_center_360_data(host_data):
+
+def test_find_center_360_data(host_data, gpu):
     eps = 1e-5
-    (cor, overlap, side, overlap_pos) = find_center_360(host_data)
+    if gpu:
+        (cor, overlap, side, overlap_pos) = find_center_360_cupy(cp.asarray(host_data))
+    else:
+        (cor, overlap, side, overlap_pos) = find_center_360(host_data)
+    
     assert_allclose(cor, 132.45317, rtol=eps)
     assert_allclose(overlap, 53.093666, rtol=eps)
     assert side == 1
@@ -52,10 +63,71 @@ def test_find_center_360_data(host_data):
     assert overlap.dtype == np.float32
 
 
-def test_find_center_360_1D_raises(host_data):
+@cp.testing.gpu
+def test_find_center_360_unity(ensure_clean_memory, have_gpu):
+    eps = 1e-5
+
+    host_data = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
+    data = cp.asarray(host_data)
+
+    (cor, overlap, side, overlap_pos) = find_center_360(host_data)
+    (cor_gpu, overlap_gpu, side_gpu, overlap_pos_gpu) = find_center_360_cupy(data)
+
+    np.testing.assert_allclose(cor, cor_gpu, rtol=eps)
+    np.testing.assert_allclose(overlap, overlap_gpu, rtol=eps)
+    np.testing.assert_allclose(side, side_gpu, rtol=eps)
+    np.testing.assert_allclose(overlap_pos, overlap_pos_gpu, rtol=eps)
+
+
+@pytest.mark.perf
+def test_find_center_360_performance(gpu):
+    host_data = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
+
+    if gpu:
+        data = cp.asarray(host_data)
+        # cold run
+        find_center_360_cupy(data)
+
+        dev = cp.cuda.Device()
+        dev.synchronize()
+
+        start = time.perf_counter_ns()
+        nvtx.RangePush("Core")
+        for _ in range(10):
+            # have to take copy, as data is modified in-place
+            find_center_360_cupy(data)
+        nvtx.RangePop()
+        dev.synchronize()
+        
+        duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
+    else:
+        # cold run
+        find_center_360(host_data)
+
+        start = time.perf_counter_ns()
+        for _ in range(10):
+            # have to take copy, as data is modified in-place
+            find_center_360(host_data)
+        
+        duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
+    
+    
+    assert "performance in ms" == duration_ms
+
+
+
+def test_find_center_360_1D_raises(host_data, gpu):
     #: 360-degree sinogram must be a 3d array
 
     with pytest.raises(ValueError):
-        find_center_360(host_data[:, 10, :])
+        if gpu:
+            find_center_360_cupy(cp.asarray(host_data[:, 10, :]))
+        else:
+            find_center_360(host_data[:, 10, :])
+    
     with pytest.raises(ValueError):
-        find_center_360(np.ones(10))
+        if gpu:
+            find_center_360_cupy(cp.ones(10))
+        else:
+            find_center_360(np.ones(10))
+        

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -31,7 +31,7 @@ def test_find_center_vo_cupy_ones(ensure_clean_memory):
 
 def test_find_center_360_ones():
     mat = np.ones(shape=(100, 100, 100))
-    (cor, overlap, side, overlap_position) = find_center_360(mat[:, 2, :])
+    (cor, overlap, side, overlap_position) = find_center_360(mat)
 
     assert_allclose(cor, 5.0)
     assert_allclose(overlap, 12.0)
@@ -41,11 +41,11 @@ def test_find_center_360_ones():
 
 def test_find_center_360_data(host_data):
     eps = 1e-5
-    (cor, overlap, side, overlap_pos) = find_center_360(host_data[:, 10, :])
-    assert_allclose(cor, 118.56627, rtol=eps)
-    assert_allclose(overlap, 80.86746, rtol=eps)
+    (cor, overlap, side, overlap_pos) = find_center_360(host_data)
+    assert_allclose(cor, 132.45317, rtol=eps)
+    assert_allclose(overlap, 53.093666, rtol=eps)
     assert side == 1
-    assert_allclose(overlap_pos, 84.13254, rtol=eps)
+    assert_allclose(overlap_pos, 111.906334, rtol=eps)
 
     #: Check that we only get a float32 output
     assert cor.dtype == np.float32
@@ -53,9 +53,9 @@ def test_find_center_360_data(host_data):
 
 
 def test_find_center_360_1D_raises(host_data):
-    #: 360-degree sinogram must be a 2d array
+    #: 360-degree sinogram must be a 3d array
 
     with pytest.raises(ValueError):
-        find_center_360(host_data[:, 10, 10])
+        find_center_360(host_data[:, 10, :])
     with pytest.raises(ValueError):
         find_center_360(np.ones(10))


### PR DESCRIPTION
This PR introduces a few test fixtures that allow to write tests both for GPU and CPU in a unified manner, and adds them to the `find_center_360` method tests. Note that the actual GPU implementation of that method is not part of the PR, so some tests raise a `NotImplementedError` for now. 

It also adds a pattern for a unity test, which compares the numpy with the cupy results and is parameterised on all possible flags.

This is how it works:

### Test that should be skipped if no GPU is available:

```python

def test_some_gpu_only_function(have_gpu):
    ...
```

### Test that should be run twice - once with and once without GPU:

```python

def test_gpu_cpu_agnostic_function(gpu):
    xp = cp if gpu else np
    data = xp.ones(...)
    
    output = function_under_test(data)
```

