### PR TITLE
GPU ported and optimised find_center_360: >420x speedup

### DIFF
--- a/httomolib/cuda_kernels/__init__.py
+++ b/httomolib/cuda_kernels/__init__.py
@@ -1,0 +1,20 @@
+import os
+from typing import List, Tuple
+import cupy as cp
+
+
+def load_cuda_module(file: str, name_expressions: List[str]=None, options: Tuple[str] = tuple()) -> cp.RawModule:
+    """Load a CUDA module file, i.e. a .cu file, from the file system,
+       compile it, and return is as a CuPy RawModule for further
+       processing.
+    """
+
+    dir = os.path.dirname(os.path.abspath(__file__))
+    file = os.path.join(dir, file + '.cu')
+     # insert a preprocessor line directive to assist compiler errors (so line numbers show correctly in output)
+    escaped = file.replace("\\", "\\\\")
+    code = '#line 1 "{}"\n'.format(escaped)
+    with open(file, 'r') as f:
+        code += f.read()
+
+    return cp.RawModule(options=('-std=c++11', *options), code=code, name_expressions=name_expressions)

--- a/httomolib/cuda_kernels/calc_metrics.cu
+++ b/httomolib/cuda_kernels/calc_metrics.cu
@@ -1,0 +1,334 @@
+/*********************************************************************
+ * Calculate correlation-based metrics for the find_center_360 method
+ *********************************************************************
+ *
+ * The core of the find_center_360 method is calculating correlation coefficients
+ * between 2 or 3 shifted matrices, over many shifting positions.
+ *
+ * This file has cuda kernels for this purpose, which provide speedups of > 300x
+ * compared to using a straight numpy to cupy port.
+ *
+ * The key is the formula to calculate the Peason correlation coefficient.
+ * This is calculated manually for every shifted matrix position in the same kernel.
+ * 
+ * The correlation coefficient between two vectors (we flatten the matrices) is:
+ *
+ * m1_norm = m1 - mean(m1)
+ * m2_norm = m2 - mean(m2)
+ * m1_sqr = dot(m1_norm, m1_norm) 
+ * m2_sqr = dot(m2_norm, m2_norm)
+ * m1_m2  = dot(m1_norm, m2_norm)
+ * r = m1_m2 / sqrt(m1_sqr * m2_sqr)
+ *
+ * The kernels in the following compute these directly pretty much, taking into 
+ * consideration normalisation, overlaps, and position offsets. Also note that the
+ * version with overlap requries 3 correlation coefficients (between 3 matrices).
+ */
+
+
+/** Function to perform a binary sum reduction for N-dimensional array storage.
+ * Note that the shared_mem pointer must have space for N * BLOCK_DIM elements.
+*/
+template <int N, int BLOCK_DIM=128>
+__device__ inline
+void sum_reduction_n(float* shared_mem, float v[N]) {
+    int tid = threadIdx.x;
+
+    float *smem[N];
+    #pragma unroll
+    for (int i = 0; i < N; ++i) {
+        smem[i] = shared_mem + i * BLOCK_DIM;
+        smem[i][tid] = v[i];
+    }
+
+    __syncthreads();
+    int nt = BLOCK_DIM;
+    int c = nt;
+    while (c > 1)
+    {
+        int half = c / 2;
+        if (tid < half)
+        {
+            #pragma unroll
+            for (int i = 0; i < N; ++i) {
+                smem[i][tid] += smem[i][c - tid - 1];
+            }
+        }
+        __syncthreads();
+        c = c - half;
+    }
+
+    // write back
+    #pragma unroll
+    for (int i = 0; i < N; ++i) {
+        v[i] = smem[i][0];
+    }
+}
+
+inline __device__
+float clip(float x, float min, float max) {
+    x = x < -1.0f ? -1.0f : x;
+    x = x > 1.0f ? 1.0f : x;
+    return x;
+}
+
+__device__ inline
+float sum_abs_row(const float* row, int win_width) 
+{
+    float sum_abs = 0.0;
+    for (int x = 0; x < win_width; ++x) {
+        sum_abs += abs(row[x]);
+    }
+    return sum_abs;
+}
+
+
+/** Compute function without overlap, where correlation metrics with 2 matrices are calculated. */
+template <bool norm>
+__device__ void _calc_metrics_no_overlap(const float *mat1, int mat1_nx,
+                                         const float *mat2, int mat2_nx,
+                                         int win_width, int rows, int side,
+                                         float *list_metric)
+{
+    // rows of the matrix
+    const int tid = threadIdx.x;
+    // position in list_pos
+    const int i = blockIdx.y;
+    const int npos = gridDim.y;
+
+    const int pos = win_width / 2 + i;
+
+    // offset matrices for position
+    const float* mat2_roi = side == 1 ? mat2 : mat2 + mat2_nx - win_width;
+    const float* mat1_roi = mat1 + (pos - win_width / 2);
+
+    extern __shared__ float smem[];
+
+    // we store our data for reductions here
+    float v[3];
+
+    ////////////////////////
+    // 1. We  need the mean of the 2 matrices (flattend)
+    v[0] = 0.0f;
+    v[1] = 0.0f;
+
+    for (int y = tid; y < rows; y += blockDim.x)
+    {
+        float norm_factor = 1.0f;
+        if (norm) {
+            norm_factor = sum_abs_row(&mat2_roi[y * mat2_nx], win_width) / 
+                sum_abs_row(&mat1_roi[y * mat1_nx], win_width);
+        }
+        for (int x = 0; x < win_width; ++x)
+        {
+            v[0] += mat1_roi[y * mat1_nx + x] * norm_factor;
+            v[1] += mat2_roi[y * mat2_nx + x];
+        }
+    }
+
+    // now reduce them to calc the mean
+    sum_reduction_n<2>(smem, v);
+
+    float mean_mat1 = v[0] / rows / win_width;
+    float mean_mat2 = v[1] / rows / win_width;
+
+    ///////////////////////////////////
+    // 2. Calculate the sum of the dot and cross-products for the 3 matrices:
+    v[0] = 0.0f;    // dot(mat1, mat1)
+    v[1] = 0.0f;    // dot(mat2, mat2)
+    v[2] = 0.0f;    // dot(mat1, mat2)
+
+    for (int y = tid; y < rows; y += blockDim.x)
+    {
+        float norm_factor = 1.0f;
+        if (norm) {
+            norm_factor = sum_abs_row(&mat2_roi[y * mat2_nx], win_width) / 
+                sum_abs_row(&mat1_roi[y * mat1_nx], win_width);
+        }
+        for (int x = 0; x < win_width; ++x)
+        {
+            float mat1_roi_val = mat1_roi[y * mat1_nx + x] * norm_factor;
+            float mat2_roi_val = mat2_roi[y * mat2_nx + x];
+            mat1_roi_val -= mean_mat1;
+            mat2_roi_val -= mean_mat2;
+            v[0] += mat1_roi_val * mat1_roi_val;
+            v[1] += mat2_roi_val * mat2_roi_val;
+            v[2] += mat1_roi_val * mat2_roi_val;
+        }
+    }
+
+    // now reduce them to calc the mean
+    sum_reduction_n<3>(smem, v);
+
+    ////////////////////////////////
+    // 3. Calculate the correlation coefficients from the covariance values
+    if (tid == 0)
+    {
+        // we actually need the mean of the squares
+        float mat1_mat1 = v[0] / (rows * win_width - 1);
+        float mat2_mat2 = v[1] / (rows * win_width - 1);
+        float mat1_mat2 = v[2] / (rows * win_width - 1);
+        // not calculate correlation coeffiecient
+        float r = mat1_mat2 / sqrt(mat1_mat1 * mat2_mat2);
+        r = clip(r, -1.0f, 1.0f);
+        // metric
+        float metric = abs(1.0f - r);
+        list_metric[i] = metric;
+    }
+}
+
+
+/** Compute function with overlap, where correlation metrics with 3 matrices are calculated. */
+template <bool norm>
+__device__ void _calc_metrics_overlap(const float *mat1, int mat1_nx,
+                                      const float *mat2, int mat2_nx,
+                                      int win_width, int rows, int side,
+                                      float *list_metric)
+{
+    // rows of the matrix
+    const int tid = threadIdx.x;
+    // position in list_pos
+    const int i = blockIdx.y;
+    const int npos = gridDim.y;
+
+    const int pos = win_width / 2 + i;
+
+    // offset matrices for position
+    const float* mat2_roi = side == 1 ? mat2 : mat2 + mat2_nx - win_width;
+    const float* mat1_roi = mat1 + (pos - win_width / 2);
+
+    extern __shared__ float smem[];
+
+    // we need to space for 6 sum reductions for calculating the correlation coefficient
+    float v[6]; 
+
+    float d_ramp = 1.0f / (win_width - 1);
+    
+    ////////////////////////
+    // 1. We  need the mean of the 3 matrices (flattend)
+    v[0] = 0.0f;
+    v[1] = 0.0f;
+    v[2] = 0.0f;
+    for (int y = tid; y < rows; y += blockDim.x)
+    {
+        float norm_factor = 1.0f;
+        if (norm) {
+            norm_factor = sum_abs_row(&mat2_roi[y * mat2_nx], win_width) / 
+                sum_abs_row(&mat1_roi[y * mat1_nx], win_width);
+        }
+        for (int x = 0; x < win_width; ++x)
+        {
+            float ramp_down = 1.0f - (x * d_ramp);
+            float ramp_up = 1.0f - ramp_down;
+            float mat1_roi_val = mat1_roi[y * mat1_nx + x] * norm_factor;
+            float mat2_roi_val = mat2_roi[y * mat2_nx + x];
+            float mat_comb_val = side == 1 ? 
+                (mat1_roi_val * ramp_down + mat2_roi_val * ramp_up) : 
+                (mat1_roi_val * ramp_up + mat2_roi_val * ramp_down);
+
+            v[0] += mat1_roi_val;
+            v[1] += mat2_roi_val;
+            v[2] += mat_comb_val;
+        }
+    }
+
+    sum_reduction_n<3>(smem, v);
+
+    float mean_mat1 = v[0] / rows / win_width;
+    float mean_mat2 = v[1] / rows / win_width;
+    float mean_mat3 = v[2] / rows / win_width;
+
+    ///////////////////////////////////
+    // 2. Calculate the sum of the dot and cross-products for the 3 matrices:
+    v[0] = 0.0f;    // dot(mat1, mat1)
+    v[1] = 0.0f;    // dot(mat2, mat2)
+    v[2] = 0.0f;    // dot(mat_comb, mat_comb)
+    v[3] = 0.0f;    // dot(mat1, mat2)
+    v[4] = 0.0f;    // dot(mat1, mat_comb)
+    v[5] = 0.0f;    // dot(mat2, mat_comb)
+
+    for (int y = tid; y < rows; y += blockDim.x)
+    {
+        float norm_factor = 1.0f;
+        if (norm) {
+            norm_factor = sum_abs_row(&mat2_roi[y * mat2_nx], win_width) / 
+                sum_abs_row(&mat1_roi[y * mat1_nx], win_width);
+        }
+        for (int x = 0; x < win_width; ++x)
+        {
+            float ramp_down = 1.0f - (x * d_ramp);
+            float ramp_up = 1.0f - ramp_down;
+            float mat1_roi_val = mat1_roi[y * mat1_nx + x] * norm_factor;
+            float mat2_roi_val = mat2_roi[y * mat2_nx + x];
+            float mat_comb_val = side == 1 ? 
+                (mat1_roi_val * ramp_down + mat2_roi_val * ramp_up) : 
+                (mat1_roi_val * ramp_up + mat2_roi_val * ramp_down);
+
+            // for covariance matrix, we need to remove the mean first
+            mat1_roi_val -= mean_mat1;
+            mat2_roi_val -= mean_mat2;
+            mat_comb_val -= mean_mat3;
+
+            // now sum the products
+            v[0] += mat1_roi_val * mat1_roi_val;
+            v[1] += mat2_roi_val * mat2_roi_val;
+            v[2] += mat_comb_val * mat_comb_val;
+            v[3] += mat1_roi_val * mat2_roi_val;
+            v[4] += mat1_roi_val * mat_comb_val;
+            v[5] += mat2_roi_val * mat_comb_val;
+        }
+
+    }
+    
+    // 6 smem reductions
+    sum_reduction_n<6>(smem, v);
+
+    ////////////////////////////////
+    // 3. Calculate the correlation coefficients from the covariance values
+    if (tid == 0)
+    {
+        // mean values
+        float mat1_mat1 = v[0] / (rows * win_width - 1);
+        float mat2_mat2 = v[1] / (rows * win_width - 1);
+        float mat3_mat3 = v[2] / (rows * win_width - 1);
+        float mat1_mat2 = v[3] / (rows * win_width - 1);
+        float mat1_mat3 = v[4] / (rows * win_width - 1);
+        float mat2_mat3 = v[5] / (rows * win_width - 1);
+        // normalise to get correlation coefficients
+        float r12 = mat1_mat2 / sqrt(mat1_mat1 * mat2_mat2);
+        float r13 = mat1_mat3 / sqrt(mat1_mat1 * mat3_mat3);
+        float r23 = mat2_mat3 / sqrt(mat2_mat2 * mat3_mat3);
+        // clip
+        r12 = clip(r12, -1.0f, 1.0f);
+        r13 = clip(r13, -1.0f, 1.0f);
+        r23 = clip(r23, -1.0f, 1.0f);
+        // metric
+        float metric_1 = abs(1.0f - r12);
+        float metric_2 = abs(1.0f - r23);
+        float metric_3 = abs(1.0f - r13);
+        // average and output
+        list_metric[i] = (metric_1 + metric_2 + metric_3) / 3.0f;
+    }
+}
+
+
+
+
+
+/** Main entry point - it calls one of the two variants above.
+ *
+ * We use a template here, so that one of the two branches gets completely eliminated by
+ * the compiler (rather than at runtime), which reduces the register count.
+ */
+template <bool norm, bool use_overlap>
+__global__ void calc_metrics_kernel(const float *mat1, int mat1_nx,
+                                    const float *mat2, int mat2_nx,
+                                    int win_width, int rows, int side,
+                                    float *list_metric)
+{
+    if (use_overlap) {
+        _calc_metrics_overlap<norm>(mat1, mat1_nx, mat2, mat2_nx, win_width, rows, side, list_metric);
+    } else {
+        _calc_metrics_no_overlap<norm>(mat1, mat1_nx, mat2, mat2_nx, win_width, rows, side, list_metric);
+    }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 packages = ["httomolib"]
 
+[tool.setuptools.package-data]
+httomolib = ["*.cu", "*.cuh"]    # include cuda kernels in package
+
 [tool.setuptools-git-versioning]
 enabled = true
 

--- a/tests/test_recon/rotation_cpu_reference.py
+++ b/tests/test_recon/rotation_cpu_reference.py
@@ -1,0 +1,198 @@
+import numpy as np
+import scipy.ndimage as ndi
+
+
+def find_center_360_numpy(
+    data: np.ndarray,
+    ind: int = None,
+    win_width: int = 10,
+    side: set = None,
+    denoise: bool = True,
+    norm: bool = False,
+    use_overlap: bool = False,
+) -> tuple[float, float, int, float]:
+    """
+    Numpy implementation - for reference in testing the cupy
+    production version.
+    """
+    if data.ndim != 3:
+        raise ValueError("A 3D array must be provided")
+
+    # this method works with a 360-degree sinogram.
+    if ind is None:
+        _sino = data[:, 0, :]
+    else:
+        _sino = data[:, ind, :]
+
+    (nrow, ncol) = _sino.shape
+    nrow_180 = nrow // 2 + 1
+    sino_top = _sino[0:nrow_180, :]
+    sino_bot = np.fliplr(_sino[-nrow_180:, :])
+    (overlap, side, overlap_position) = _find_overlap(
+        sino_top, sino_bot, win_width, side, denoise, norm, use_overlap
+    )
+    if side == 0:
+        cor = overlap / 2.0 - 1.0
+    else:
+        cor = ncol - overlap / 2.0 - 1.0
+
+    return np.float32(cor), np.float32(overlap), side, np.float32(overlap_position)
+
+
+def _find_overlap(
+    mat1, mat2, win_width, side=None, denoise=True, norm=False, use_overlap=False
+):
+    ncol1 = mat1.shape[1]
+    ncol2 = mat2.shape[1]
+    win_width = int(np.clip(win_width, 6, min(ncol1, ncol2) // 2))
+
+    if side == 1:
+        (list_metric, offset) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=side,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
+        overlap_position = _calculate_curvature(list_metric)[1]
+        overlap_position += offset
+        overlap = ncol1 - overlap_position + win_width // 2
+    elif side == 0:
+        (list_metric, offset) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=side,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
+        overlap_position = _calculate_curvature(list_metric)[1]
+        overlap_position += offset
+        overlap = overlap_position + win_width // 2
+    else:
+        (list_metric1, offset1) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=1,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
+        (list_metric2, offset2) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=0,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
+
+        (curvature1, overlap_position1) = _calculate_curvature(list_metric1)
+        overlap_position1 += offset1
+        (curvature2, overlap_position2) = _calculate_curvature(list_metric2)
+        overlap_position2 += offset2
+
+        if curvature1 > curvature2:
+            side = 1
+            overlap_position = overlap_position1
+            overlap = ncol1 - overlap_position + win_width // 2
+        else:
+            side = 0
+            overlap_position = overlap_position2
+            overlap = overlap_position + win_width // 2
+
+    return overlap, side, overlap_position
+
+
+def _search_overlap(
+    mat1, mat2, win_width, side, denoise=True, norm=False, use_overlap=False
+):
+    if denoise is True:
+        mat1 = ndi.gaussian_filter(mat1, (2, 2), mode="reflect")
+        mat2 = ndi.gaussian_filter(mat2, (2, 2), mode="reflect")
+    (nrow1, ncol1) = mat1.shape
+    (nrow2, ncol2) = mat2.shape
+
+    if nrow1 != nrow2:
+        raise ValueError("Two images are not at the same height!!!")
+
+    win_width = int(np.clip(win_width, 6, min(ncol1, ncol2) // 2 - 1))
+    offset = win_width // 2
+    win_width = 2 * offset  # Make it even
+    ramp_down = np.linspace(1.0, 0.0, win_width, dtype=np.float32)
+    ramp_down = ramp_down.reshape((1, ramp_down.size))
+    ramp_up = 1.0 - ramp_down
+
+    if side == 1:
+        mat2_roi = mat2[:, 0:win_width]
+        mat2_roi_wei = mat2_roi * ramp_up
+    else:
+        mat2_roi = mat2[:, ncol2 - win_width :]
+        mat2_roi_wei = mat2_roi * ramp_down
+
+    list_mean2 = np.mean(np.abs(mat2_roi), axis=1, keepdims=True)  # (Nx1)
+    list_pos = np.arange(offset, ncol1 - offset)
+    num_metric = len(list_pos)
+    list_metric = np.empty(num_metric, dtype=np.float32)
+
+    mat1_roi = np.empty((mat1.shape[0], 2 * offset), dtype=np.float32)
+
+    for i, pos in enumerate(list_pos):
+        mat1_roi[:] = mat1[:, pos - offset : pos + offset]
+        if norm is True:
+            list_fact = np.mean(np.abs(mat1_roi), axis=1, keepdims=True)
+            np.divide(list_mean2, list_fact, out=list_fact)
+            mat1_roi *= list_fact
+
+        if use_overlap is True:
+            if side == 1:
+                mat_comb = mat1_roi * ramp_down
+            else:
+                mat_comb = mat1_roi * ramp_up
+            mat_comb += mat2_roi_wei
+            list_metric[i] = (
+                _correlation_metric(mat1_roi, mat2_roi)
+                + _correlation_metric(mat1_roi, mat_comb)
+                + _correlation_metric(mat2_roi, mat_comb)
+            ) / 3.0
+        else:
+            list_metric[i] = _correlation_metric(mat1_roi, mat2_roi)
+    min_metric = np.min(list_metric)
+    if min_metric != 0.0:
+        list_metric = list_metric / min_metric
+
+    return list_metric, offset
+
+
+def _calculate_curvature(list_metric):
+    radi = 2
+    num_metric = list_metric.size
+    min_metric_idx = int(np.argmin(list_metric))
+    min_pos = int(np.clip(min_metric_idx, radi, num_metric - radi - 1))
+
+    # work mostly on CPU here - we have very small arrays here
+    list1 = list_metric[min_pos - radi : min_pos + radi + 1]
+    afact1 = np.polyfit(np.arange(0, 2 * radi + 1), list1, 2)[0]
+    list2 = list_metric[min_pos - 1 : min_pos + 2]
+    (afact2, bfact2, _) = np.polyfit(np.arange(min_pos - 1, min_pos + 2), list2, 2)
+
+    curvature = np.abs(afact1)
+    if afact2 != 0.0:
+        num = -bfact2 / (2 * afact2)
+        if (num >= min_pos - 1) and (num <= min_pos + 1):
+            min_pos = num
+
+    return curvature, np.float32(min_pos)
+
+
+def _correlation_metric(mat1, mat2):
+    # pearsonr coefficient
+    assert mat1.size == mat2.size, "matrices must be same size"
+    X = np.vstack((mat1.reshape((1, mat1.size)), mat2.reshape((1, mat2.size))))
+    r = np.corrcoef(X)
+    return float(np.abs(1.0 - r[0, 1]))

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -6,6 +6,7 @@ import pytest
 from httomolib.prep.normalize import normalize_cupy
 from httomolib.recon.rotation import find_center_360, find_center_vo_cupy
 from numpy.testing import assert_allclose
+from .rotation_cpu_reference import find_center_360_numpy
 
 
 @cp.testing.gpu
@@ -31,38 +32,6 @@ def test_find_center_vo_cupy_ones(ensure_clean_memory):
     mat = None #: free up GPU memory
 
 
-def test_find_center_360_ones():
-    mat = np.ones(shape=(100, 100, 100))
-    (cor, overlap, side, overlap_position) = find_center_360(mat)
-
-    assert_allclose(cor, 5.0)
-    assert_allclose(overlap, 12.0)
-    assert side == 0
-    assert_allclose(overlap_position, 7.0)
-
-
-def test_find_center_360_data(host_data):
-    eps = 1e-5
-    (cor, overlap, side, overlap_pos) = find_center_360(host_data)
-    assert_allclose(cor, 132.45317, rtol=eps)
-    assert_allclose(overlap, 53.093666, rtol=eps)
-    assert side == 1
-    assert_allclose(overlap_pos, 111.906334, rtol=eps)
-
-    #: Check that we only get a float32 output
-    assert cor.dtype == np.float32
-    assert overlap.dtype == np.float32
-
-
-def test_find_center_360_1D_raises(host_data):
-    #: 360-degree sinogram must be a 3d array
-
-    with pytest.raises(ValueError):
-        find_center_360(host_data[:, 10, :])
-    with pytest.raises(ValueError):
-        find_center_360(np.ones(10))
-
-
 @cp.testing.gpu
 @pytest.mark.perf
 def test_find_center_vo_cupy_performance():
@@ -82,3 +51,90 @@ def test_find_center_vo_cupy_performance():
     duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
 
     assert "performance in ms" == duration_ms
+
+
+@cp.testing.gpu
+def test_find_center_360_ones():
+    mat = cp.ones(shape=(100, 100, 100), dtype=cp.float32)
+    
+    (cor, overlap, side, overlap_position) = find_center_360(mat)
+
+    assert_allclose(cor, 5.0)
+    assert_allclose(overlap, 12.0)
+    assert side == 0
+    assert_allclose(overlap_position, 7.0)
+
+
+@cp.testing.gpu
+def test_find_center_360_data(data):
+    eps = 1e-5
+    (cor, overlap, side, overlap_pos) = find_center_360(data, norm=True, denoise=False)
+    
+    assert_allclose(cor, 132.45317, rtol=eps)
+    assert_allclose(overlap, 53.093666, rtol=eps)
+    assert side == 1
+    assert_allclose(overlap_pos, 111.906334, rtol=eps)
+
+    #: Check that we only get a float32 output
+    assert cor.dtype == np.float32
+    assert overlap.dtype == np.float32
+
+
+@cp.testing.gpu
+@pytest.mark.parametrize("norm", [False, True], ids=["no_normalise", "normalise"])
+@pytest.mark.parametrize("overlap", [False, True], ids=["no_overlap", "overlap"])
+@pytest.mark.parametrize("denoise", [False, True], ids=["no_denoise", "denoise"])
+@pytest.mark.parametrize("side", [1, 0])
+@cp.testing.numpy_cupy_allclose(rtol=1e-5, atol=1e-6)
+def test_find_center_360_unity(ensure_clean_memory, xp, norm, overlap, denoise, side):
+    # because it's random, we explicitly seed and use numpy only, to match the data
+    np.random.seed(12345)
+    data = np.random.random_sample(size=(128, 1, 512)).astype(np.float32) * 2.0 + 0.001
+    data = xp.asarray(data)
+
+    if xp.__name__ == "numpy":
+        (cor, overlap, side, overlap_pos) = find_center_360_numpy(data, use_overlap=overlap, 
+                                                            norm=norm, denoise=denoise, 
+                                                            side=side)
+    else:
+        (cor, overlap, side, overlap_pos) = find_center_360(data, use_overlap=overlap, 
+                                                            norm=norm, denoise=denoise, 
+                                                            side=side)
+
+    return xp.asarray([cor, overlap, side, overlap_pos])
+    
+
+
+@pytest.mark.perf
+def test_find_center_360_performance(ensure_clean_memory):
+    data = cp.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
+
+    # cold run
+    find_center_360(data, use_overlap=True, norm=True, denoise=True)
+
+    dev = cp.cuda.Device()
+    dev.synchronize()
+
+    start = time.perf_counter_ns()
+    nvtx.RangePush("Core")
+    for _ in range(10):
+        # have to take copy, as data is modified in-place
+        find_center_360(data, use_overlap=True, norm=True, denoise=True)
+    nvtx.RangePop()
+    dev.synchronize()
+    
+    duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
+    
+    assert "performance in ms" == duration_ms
+
+
+@cp.testing.gpu
+def test_find_center_360_1D_raises(data):
+    
+    #: 360-degree sinogram must be a 3d array
+    with pytest.raises(ValueError):
+        find_center_360(data[:, 10, :])
+    
+    with pytest.raises(ValueError):
+        find_center_360(cp.ones(10))
+        


### PR DESCRIPTION
## Overview

This PR ports the `find_center_360` function to the GPU using cupy, and optimises the function on both CPU and GPU. It also adds appropriate tests and compares it to the CPU reference in all combinations of flags.

## Performance (426x faster)

Based on the performance test in this PR, with normalisation, filtering, and overlap enabled. Measured on Diamond cluster, V100

* Starting performance CPU: **~3,070ms**
* Straight port to Cupy, using `get_array_module`: **~7,150ms**
* Final performance CPU: **~1,580ms**
* Final performance GPU: **~7.2ms** (426x faster than initial CPU, 993x faster than straight GPU port)

## Details

* The key item was to put the calculation of all the correlation metrics (with all possible position shifts) into a single kernel
* The Pearson correlation coefficient can in fact be calculated easily by hand, for every position in a different thread block
* Also removed a lot of temporary arrays and small operations, which also benefited the CPU implementation
* Apart from that, unified tests have been added and the CUDA code has been moved into its own folder, which makes development much easier and code better organised
