### PR TITLE
Remove cupy suffix, factor out .cu files, and reformat

### DIFF
--- a/httomolib/cuda_kernels/__init__.py
+++ b/httomolib/cuda_kernels/__init__.py
@@ -3,18 +3,22 @@ from typing import List, Tuple
 import cupy as cp
 
 
-def load_cuda_module(file: str, name_expressions: List[str]=None, options: Tuple[str] = tuple()) -> cp.RawModule:
+def load_cuda_module(
+    file: str, name_expressions: List[str] = None, options: Tuple[str] = tuple()
+) -> cp.RawModule:
     """Load a CUDA module file, i.e. a .cu file, from the file system,
-       compile it, and return is as a CuPy RawModule for further
-       processing.
+    compile it, and return is as a CuPy RawModule for further
+    processing.
     """
 
     dir = os.path.dirname(os.path.abspath(__file__))
-    file = os.path.join(dir, file + '.cu')
-     # insert a preprocessor line directive to assist compiler errors (so line numbers show correctly in output)
+    file = os.path.join(dir, file + ".cu")
+    # insert a preprocessor line directive to assist compiler errors (so line numbers show correctly in output)
     escaped = file.replace("\\", "\\\\")
     code = '#line 1 "{}"\n'.format(escaped)
-    with open(file, 'r') as f:
+    with open(file, "r") as f:
         code += f.read()
 
-    return cp.RawModule(options=('-std=c++11', *options), code=code, name_expressions=name_expressions)
+    return cp.RawModule(
+        options=("-std=c++11", *options), code=code, name_expressions=name_expressions
+    )

--- a/httomolib/cuda_kernels/center_360_shifts.cu
+++ b/httomolib/cuda_kernels/center_360_shifts.cu
@@ -1,0 +1,49 @@
+#include <cupy/complex.cuh>
+
+extern "C" __global__ void
+shift_whole_shifts(const float *sino2, const float *sino3,
+                   const float *__restrict__ list_shift, float *mat, int nx,
+                   int nymat) {
+  int xid = threadIdx.x + blockIdx.x * blockDim.x;
+  int yid = blockIdx.y;
+  int zid = blockIdx.z;
+  int ny = gridDim.y;
+
+  if (xid >= nx)
+    return;
+
+  float shift_col = list_shift[zid];
+  float int_part = 0.0;
+  float frac_part = modf(shift_col, &int_part);
+  if (abs(frac_part) > 1e-5f) {
+    // we have a floating point shift, so we only roll in
+    // sino3, but we leave the rest for later using scipy
+    int shift_int =
+        shift_col >= 0.0 ? int(ceil(shift_col)) : int(floor(shift_col));
+    if (shift_int >= 0 && xid < shift_int) {
+      mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+    }
+    if (shift_int < 0 && xid >= nx + shift_int) {
+      mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+    }
+  } else {
+    // we have an integer shift, so we can roll in directly
+    // by indexing
+    int shift_int = int(shift_col);
+    if (shift_int >= 0) {
+      if (xid >= shift_int) {
+        mat[zid * nymat * nx + yid * nx + xid] =
+            sino2[yid * nx + xid - shift_int];
+      } else {
+        mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+      }
+    } else {
+      if (xid < nx + shift_int) {
+        mat[zid * nymat * nx + yid * nx + xid] =
+            sino2[yid * nx + xid - shift_int];
+      } else {
+        mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
+      }
+    }
+  }
+}

--- a/httomolib/cuda_kernels/downsample_sino.cu
+++ b/httomolib/cuda_kernels/downsample_sino.cu
@@ -1,0 +1,36 @@
+extern "C" __global__ void downsample_sino(float *sino, int dx, int dz,
+                                           int level, float *out) {
+  // use shared memory to store the values used to "merge" columns of the
+  // sinogram in the downsampling process
+  extern __shared__ float downsampled_vals[];
+  unsigned int binsize, i, j, k, orig_ind, out_ind, output_bin_no;
+  i = blockDim.x * blockIdx.x + threadIdx.x;
+  j = 0;
+  k = blockDim.y * blockIdx.y + threadIdx.y;
+  orig_ind = (k * dz) + i;
+  binsize = 1 << level;
+  unsigned int dz_downsampled =
+      __float2uint_rd(fdividef(__uint2float_rd(dz), __uint2float_rd(binsize)));
+  unsigned int i_downsampled =
+      __float2uint_rd(fdividef(__uint2float_rd(i), __uint2float_rd(binsize)));
+  if (orig_ind < dx * dz) {
+    output_bin_no =
+        __float2uint_rd(fdividef(__uint2float_rd(i), __uint2float_rd(binsize)));
+    out_ind = (k * dz_downsampled) + i_downsampled;
+    downsampled_vals[threadIdx.y * 8 + threadIdx.x] =
+        sino[orig_ind] / __uint2float_rd(binsize);
+    // synchronise threads within thread-block so that it's guaranteed
+    // that all the required values have been copied into shared memeory
+    // to then sum and save in the downsampled output
+    __syncthreads();
+    // arbitrarily use the "beginning thread" in each "lot" of pixels
+    // for downsampling to then save the desired value in the
+    // downsampled output array
+    if (i % 4 == 0) {
+      out[out_ind] = downsampled_vals[threadIdx.y * 8 + threadIdx.x] +
+                     downsampled_vals[threadIdx.y * 8 + threadIdx.x + 1] +
+                     downsampled_vals[threadIdx.y * 8 + threadIdx.x + 2] +
+                     downsampled_vals[threadIdx.y * 8 + threadIdx.x + 3];
+    }
+  }
+}

--- a/httomolib/cuda_kernels/generate_filtersync.cu
+++ b/httomolib/cuda_kernels/generate_filtersync.cu
@@ -1,0 +1,78 @@
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795f
+#endif
+
+extern "C" __global__ void generate_filtersinc(float a, float *f, int n,
+                                               float multiplier) {
+  int tid = threadIdx.x; // using only one block
+
+  float dw = 2 * M_PI / n;
+
+  extern __shared__ char smem_raw[];
+  float *smem = reinterpret_cast<float *>(smem_raw);
+
+  // from: cp.linalg.pinv(rd_c)
+  // pseudo-inverse of vector is x/sum(x**2),
+  // so we need to compute sum(x**2) in shared memory
+  float sum = 0.0;
+  for (int i = tid; i < n; i += blockDim.x) {
+    float w = -M_PI + i * dw;
+    float rn2 = a * w / 2.0f;
+    sum += rn2 * rn2;
+  }
+
+  smem[tid] = sum;
+  __syncthreads();
+  int nt = blockDim.x;
+  int c = nt;
+  while (c > 1) {
+    int half = c / 2;
+    if (tid < half) {
+      smem[tid] += smem[c - tid - 1];
+    }
+    __syncthreads();
+    c = c - half;
+  }
+  float sum_aw2_sqr = smem[0];
+
+  // cp.dot(rn2, cp.linalg.pinv(rd_c))**2
+  // now we can calclate the dot product, preparing summing in shared memory
+  float dot_partial = 0.0;
+  for (int i = tid; i < n; i += blockDim.x) {
+    float w = -M_PI + i * dw;
+    float rd = a * w / 2.0f;
+    float rn2 = sin(rd);
+
+    dot_partial += rn2 * rd / sum_aw2_sqr;
+  }
+
+  // now reduce dot_partial to full dot-product result
+  smem[tid] = dot_partial;
+  __syncthreads();
+  c = nt;
+  while (c > 1) {
+    int half = c / 2;
+    if (tid < half) {
+      smem[tid] += smem[c - tid - 1];
+    }
+    __syncthreads();
+    c = c - half;
+  }
+  float dotprod_sqr = smem[0] * smem[0];
+
+  // now compute actual result
+  for (int i = tid; i < n; i += blockDim.x) {
+    float w = -M_PI + i * dw;
+    float rd = a * w / 2.0f;
+    float rn2 = sin(rd);
+    float rn1 = abs(2.0 / a * rn2);
+    float r = rn1 * dotprod_sqr;
+
+    // write to ifftshifted positions
+    int shift = n / 2;
+    int outidx = (i + shift) % n;
+
+    // apply multiplier here - which does FFT scaling too
+    f[outidx] = r * multiplier;
+  }
+}

--- a/httomolib/cuda_kernels/generate_mask.cu
+++ b/httomolib/cuda_kernels/generate_mask.cu
@@ -1,0 +1,53 @@
+extern "C" __global__ void generate_mask(const int ncol, const int nrow,
+                                         const int cen_col, const int cen_row,
+                                         const float du, const float dv,
+                                         const float radius, const float drop,
+                                         unsigned short *mask) {
+  int i = blockDim.x * blockIdx.x + threadIdx.x;
+  int j = blockDim.y * blockIdx.y + threadIdx.y;
+
+  if (j >= nrow || i >= ncol)
+    return;
+
+  int pos = __float2int_ru(((j - cen_row) * dv / radius) / du);
+  int pos1 = -pos + cen_col;
+  int pos2 = pos + cen_col;
+
+  if (pos1 > pos2) {
+    int temp = pos1;
+    pos1 = pos2;
+    pos2 = temp;
+    if (pos1 >= ncol) {
+      pos1 = ncol - 1;
+    }
+    if (pos2 < 0) {
+      pos2 = 0;
+    }
+  } else {
+    if (pos1 < 0) {
+      pos1 = 0;
+    }
+    if (pos2 >= ncol) {
+      pos2 = ncol - 1;
+    }
+  }
+
+  short outval = (pos1 <= i && i <= pos2) ? 1 : 0;
+
+  // mask[cen_row - drop: cen_row + drop + 1, :] = 0
+  if (j >= cen_row - drop && j <= cen_row + drop) {
+    outval = 0;
+  }
+  // mask[:, cen_col - 1: cen_col + 2] = 0
+  if (i >= cen_col - 1 && i <= cen_col + 1) {
+    outval = 0;
+  }
+
+  // write to ifft-shifted positions
+  int ishift = (ncol + 1) / 2;
+  int jshift = (nrow + 1) / 2;
+  int outi = (i + ishift) % ncol;
+  int outj = (j + jshift) % nrow;
+
+  mask[outj * ncol + outi] = outval;
+}

--- a/httomolib/cuda_kernels/median_kernel.cu
+++ b/httomolib/cuda_kernels/median_kernel.cu
@@ -1,0 +1,55 @@
+template <typename Type, int diameter>
+__global__ void median_general_kernel(const Type *in, Type *out, float dif,
+                                      int Z, int M, int N) {
+  constexpr int radius = diameter / 2;
+  constexpr int d3 = diameter * diameter * diameter;
+  constexpr int midpoint = d3 / 2;
+
+  Type ValVec[d3];
+  const long i = blockDim.x * blockIdx.x + threadIdx.x;
+  const long j = blockDim.y * blockIdx.y + threadIdx.y;
+  const long k = blockDim.z * blockIdx.z + threadIdx.z;
+
+  if (i >= N || j >= M || k >= Z)
+    return;
+
+  int counter = 0;
+  for (int i_m = -radius; i_m <= radius; i_m++) {
+    int i1 = i + i_m;
+    if ((i1 < 0) || (i1 >= N))
+      i1 = i;
+    for (int j_m = -radius; j_m <= radius; j_m++) {
+      int j1 = j + j_m;
+      if ((j1 < 0) || (j1 >= M))
+        j1 = j;
+      for (int k_m = -radius; k_m <= radius; k_m++) {
+        int k1 = k + k_m;
+        if ((k1 < 0) || (k1 >= Z))
+          k1 = k;
+        ValVec[counter] = in[i1 + N * j1 + N * M * k1];
+        counter++;
+      }
+    }
+  }
+
+  /* do bubble sort here */
+  for (int x = 0; x < d3 - 1; x++) {
+    for (int y = 0; y < d3 - x - 1; y++) {
+      if (ValVec[y] > ValVec[y + 1]) {
+        Type temp = ValVec[y];
+        ValVec[y] = ValVec[y + 1];
+        ValVec[y + 1] = temp;
+      }
+    }
+  }
+
+  /* perform median filtration */
+  if (dif == 0.0f)
+    out[i + N * j + N * M * k] = ValVec[midpoint];
+  else {
+    /* perform dezingering */
+    Type in_value = in[i + N * j + N * M * k];
+    out[i + N * j + N * M * k] =
+        fabsf(in_value - ValVec[midpoint]) >= dif ? ValVec[midpoint] : in_value;
+  }
+}

--- a/httomolib/cuda_kernels/paganin_filter_gen.cu
+++ b/httomolib/cuda_kernels/paganin_filter_gen.cu
@@ -1,0 +1,37 @@
+#include <cupy/complex.cuh>
+
+#ifndef M_PI
+#define M_PI 3.1415926535897932384626433832795f
+#endif
+
+extern "C" __global__ void
+paganin_filter_gen(int width1, int height1, float resolution, float wavelength,
+                   float distance, float ratio, complex<float> *filtercomplex) {
+  int px = threadIdx.x + blockIdx.x * blockDim.x;
+  int py = threadIdx.y + blockIdx.y * blockDim.y;
+  if (px >= width1)
+    return;
+  if (py >= height1)
+    return;
+
+  float dpx = 1.0f / (width1 * resolution);
+  float dpy = 1.0f / (height1 * resolution);
+  int centerx = (width1 + 1) / 2 - 1;
+  int centery = (height1 + 1) / 2 - 1;
+
+  float pxx = (px - centerx) * dpx;
+  float pyy = (py - centery) * dpy;
+  float pd = (pxx * pxx + pyy * pyy) * wavelength * distance * M_PI;
+             ;
+  float filter1 = 1.0f + ratio * pd;
+
+  complex<float> value = 1.0f / complex<float>(filter1, filter1);
+
+  // ifftshifting positions
+  int xshift = (width1 + 1) / 2;
+  int yshift = (height1 + 1) / 2;
+  int outX = (px + xshift) % width1;
+  int outY = (py + yshift) % height1;
+
+  filtercomplex[outY * width1 + outX] = value;
+}

--- a/httomolib/misc/corr.py
+++ b/httomolib/misc/corr.py
@@ -28,17 +28,17 @@ except ImportError:
 
 import numpy as np
 
-__all__ = [    
-    'median_filter3d_cupy',
-    'remove_outlier3d_cupy',
-    'inpainting_filter3d',
+from httomolib.cuda_kernels import load_cuda_module
+
+__all__ = [
+    "median_filter3d",
+    "remove_outlier3d",
+    "inpainting_filter3d",
 ]
 
 
-def median_filter3d_cupy(
-    data: cp.ndarray,
-    kernel_size: int = 3,
-    dif: float = 0.0
+def median_filter3d(
+    data: cp.ndarray, kernel_size: int = 3, dif: float = 0.0
 ) -> cp.ndarray:
     """
     Apply 3D median or dezinger (when dif>0) filter to a 3D array.
@@ -50,7 +50,7 @@ def median_filter3d_cupy(
     kernel_size : int, optional
         The size of the filter's kernel.
     dif : float, optional
-        Expected difference value between outlier value and the 
+        Expected difference value between outlier value and the
         median value of the array, leave equal to 0 for classical median.
 
     Returns
@@ -68,117 +68,41 @@ def median_filter3d_cupy(
     if input_type not in ["float32", "uint16"]:
         raise ValueError("The input data should be either float32 or uint16 data type")
 
-    
     if data.ndim == 3:
         if 0 in data.shape:
             raise ValueError("The length of one of dimensions is equal to zero")
     else:
         raise ValueError("The input array must be a 3D array")
 
+    if kernel_size not in [3, 5, 7, 9, 11, 13]:
+        raise ValueError("Please select a correct kernel size: 3, 5, 7, 9, 11, 13")
+
+    kernel_args = "median_general_kernel<{0}, {1}>".format(
+        "float" if input_type == "float32" else "unsigned short", kernel_size
+    )
+    median_module = load_cuda_module("median_kernel", name_expressions=[kernel_args])
+    median3d = median_module.get_function(kernel_args)
+
     out = cp.empty(data.shape, dtype=input_type, order="C")
-    
-    median_kernel = r'''
-        template <typename Type, int diameter>
-        __global__ void median_general_kernel(
-            const Type* in, Type* out, float dif, int Z, int M, int N)
-        {
-            constexpr int radius = diameter / 2;
-            constexpr int d3 = diameter*diameter*diameter;
-            constexpr int midpoint = d3 / 2;
 
-            Type ValVec[d3];
-            const long i = blockDim.x * blockIdx.x + threadIdx.x;
-            const long j = blockDim.y * blockIdx.y + threadIdx.y;
-            const long k = blockDim.z * blockIdx.z + threadIdx.z;
-
-            if (i >= N || j >= M || k >= Z)
-                return; 
-            
-            int counter = 0;
-            for(int i_m=-radius; i_m<=radius; i_m++)
-            {
-                int i1 = i + i_m;
-                if ((i1 < 0) || (i1 >= N))
-                    i1 = i;
-                for(int j_m=-radius; j_m<=radius; j_m++)
-                {
-                    int j1 = j + j_m;
-                    if ((j1 < 0) || (j1 >= M))
-                        j1 = j;
-                    for(int k_m=-radius; k_m<=radius; k_m++)
-                    {
-                        int k1 = k + k_m;
-                        if ((k1 < 0) || (k1 >= Z))
-                            k1 = k;
-                        ValVec[counter] = in[i1 + N*j1 + N*M*k1];
-                        counter++;
-                    }
-                }
-            }
-
-            /* do bubble sort here */
-            for (int x = 0; x < d3 - 1; x++)
-            {
-                for(int y = 0; y < d3 - x - 1; y++)
-                {
-                    if (ValVec[y] > ValVec[y+1])
-                    {
-                        Type temp = ValVec[y];
-                        ValVec[y] = ValVec[y+1];
-                        ValVec[y+1] = temp;
-                    }
-                }
-            }
-            
-            /* perform median filtration */
-            if (dif == 0.0f)
-                out[i + N*j + N*M*k] = ValVec[midpoint];
-            else
-            {
-                /* perform dezingering */
-                Type in_value = in[i + N*j + N*M*k];
-                out[i + N*j + N*M*k] = fabsf(in_value - ValVec[midpoint]) >= dif ? ValVec[midpoint] : in_value;
-            }
-        
-        }
-    '''
     dz, dy, dx = data.shape
     # setting grid/block parameters
     block_x = 128
-    block_y = 1
-    block_z = 1
-    block_dims = (block_x, block_y, block_z)
+    block_dims = (block_x, 1, 1)
     grid_x = (dx + block_x - 1) // block_x
     grid_y = dy
     grid_z = dz
-    grid_dims = (grid_x, grid_y, grid_z) 
+    grid_dims = (grid_x, grid_y, grid_z)
 
-    params = (data, out, dif, dz, dy, dx, dx*dy*dz)
+    params = (data, out, dif, dz, dy, dx, dx * dy * dz)
 
-    if kernel_size in [3, 5, 7, 9, 11, 13]:
-        kernel_args = "median_general_kernel<{0}, {1}>".format(
-            "float" if input_type == "float32" else "unsigned short",
-            kernel_size
-        )
-    else:
-        raise ValueError("Please select a correct kernel size: 3, 5, 7, 9, 11, 13")
-
-    module = cp.RawModule(
-        code=median_kernel,
-        options=('-std=c++11',),
-        name_expressions=[kernel_args]
-    )
-    
-    median3d = module.get_function(kernel_args)
     median3d(grid_dims, block_dims, params)
 
     return out
 
 
-def remove_outlier3d_cupy(
-    data: cp.ndarray,
-    kernel_size: int = 3,
-    dif: float = 0.1
+def remove_outlier3d(
+    data: cp.ndarray, kernel_size: int = 3, dif: float = 0.1
 ) -> cp.ndarray:
     """
     Selectively applies 3D median filter to a 3D array to remove outliers. Also called a dezinger.
@@ -190,7 +114,7 @@ def remove_outlier3d_cupy(
     kernel_size : int, optional
         The size of the filter's kernel.
     dif : float, optional
-        Expected difference value between outlier value and the 
+        Expected difference value between outlier value and the
         median value of the array.
 
     Returns
@@ -202,12 +126,8 @@ def remove_outlier3d_cupy(
     ------
     ValueError
         If the input array is not three dimensional.
-    """                        
-    return median_filter3d_cupy(
-        data=data,
-        kernel_size=kernel_size,
-        dif=dif
-    )
+    """
+    return median_filter3d(data=data, kernel_size=kernel_size, dif=dif)
 
 
 def inpainting_filter3d(
@@ -216,7 +136,7 @@ def inpainting_filter3d(
     iter: int = 3,
     windowsize_half: int = 5,
     method_type: str = "random",
-    ncore: int = 1
+    ncore: int = 1,
 ) -> np.ndarray:
     """
     Inpainting filter for 3D data, taken from the Larix toolbox
@@ -251,5 +171,5 @@ def inpainting_filter3d(
     """
 
     from larix.methods.misc import INPAINT_EUCL_WEIGHTED
-  
+
     return INPAINT_EUCL_WEIGHTED(data, mask, iter, windowsize_half, method_type, ncore)

--- a/httomolib/misc/images.py
+++ b/httomolib/misc/images.py
@@ -29,22 +29,22 @@ from PIL import Image
 from skimage import exposure
 
 __all__ = [
-    'save_to_images',
+    "save_to_images",
 ]
 
 
 def save_to_images(
     data: ndarray,
     out_dir: str,
-    subfolder_name: str = 'images',
+    subfolder_name: str = "images",
     axis: int = 0,
-    file_format: str = 'tif',
+    file_format: str = "tif",
     bits: int = 8,
     perc_range_min: float = 0.0,
     perc_range_max: float = 100.0,
     jpeg_quality: int = 95,
     glob_stats: tuple = None,
-    comm_rank: int = 0
+    comm_rank: int = 0,
 ):
     """
     Saves data as 2D images.
@@ -82,8 +82,10 @@ def save_to_images(
 
     if bits not in [8, 16, 32]:
         bits = 32
-        print("The selected bit type %s is not available, "
-            "resetting to 32 bit \n" % str(bits))
+        print(
+            "The selected bit type %s is not available, "
+            "resetting to 32 bit \n" % str(bits)
+        )
 
     # create the output folder
     subsubfolder_name = f"images{str(bits)}bit_{str(file_format)}"
@@ -94,13 +96,7 @@ def save_to_images(
         if not os.path.isdir(path_to_images_dir):
             raise
 
-    data = np.nan_to_num(
-        data,
-        copy=False,
-        nan=0.0,
-        posinf=0,
-        neginf=0
-    )
+    data = np.nan_to_num(data, copy=False, nan=0.0, posinf=0, neginf=0)
 
     if glob_stats is None:
         glob_stats = (
@@ -114,8 +110,13 @@ def save_to_images(
         for i in range(slice_dim_size):
             filename = f"{i + comm_rank*slice_dim_size:05d}.{file_format}"
             filepath = os.path.join(path_to_images_dir, f"{filename}")
-            _save_single_img(data.take(indices=i, axis=axis), glob_stats, bits,
-                             jpeg_quality, filepath)
+            _save_single_img(
+                data.take(indices=i, axis=axis),
+                glob_stats,
+                bits,
+                jpeg_quality,
+                filepath,
+            )
     else:
         filename = f"{1:05d}.{file_format}"
         filepath = os.path.join(path_to_images_dir, f"{filename}")
@@ -123,29 +124,23 @@ def save_to_images(
 
 
 def _save_single_img(array2d, glob_stats, bits, jpeg_quality, path_to_out_file):
-    """ Rescales to the bit chosen and saves the image. """
+    """Rescales to the bit chosen and saves the image."""
     data_min = glob_stats[0]
     data_max = glob_stats[1]
 
     if bits == 8:
         array2d = exposure.rescale_intensity(
-            array2d,
-            in_range=(data_min, data_max),
-            out_range=(0, 255)
+            array2d, in_range=(data_min, data_max), out_range=(0, 255)
         ).astype(np.uint8)
 
     elif bits == 16:
         array2d = exposure.rescale_intensity(
-            array2d,
-            in_range=(data_min, data_max),
-            out_range=(0, 65535)
+            array2d, in_range=(data_min, data_max), out_range=(0, 65535)
         ).astype(np.uint16)
 
     else:
         array2d = exposure.rescale_intensity(
-            array2d,
-            in_range=(data_min, data_max),
-            out_range=(data_min, data_max)
+            array2d, in_range=(data_min, data_max), out_range=(data_min, data_max)
         ).astype(np.uint32)
 
     img = Image.fromarray(array2d)

--- a/httomolib/misc/segm.py
+++ b/httomolib/misc/segm.py
@@ -19,14 +19,14 @@
 # Created Date: 25/October/2022
 # version ='0.1'
 # ---------------------------------------------------------------------------
-"""Modules for data segmentation and thresholding""" 
+"""Modules for data segmentation and thresholding"""
 
 import numpy as np
 from numpy import ndarray
 from skimage import filters
 
 __all__ = [
-    'binary_thresholding',
+    "binary_thresholding",
 ]
 
 
@@ -35,7 +35,7 @@ def binary_thresholding(
     val_intensity: float = 0.1,
     otsu: bool = False,
     foreground: bool = True,
-    axis: int = 1
+    axis: int = 1,
 ) -> ndarray:
     """
     Performs binary thresholding to the input data
@@ -52,7 +52,7 @@ def binary_thresholding(
     foreground : bool, optional
         Get the foreground, otherwise background.
     axis : int, optional
-        Specify the axis to use to slice the data (if data is the 3D array).        
+        Specify the axis to use to slice the data (if data is the 3D array).
 
     Returns
     -------
@@ -75,7 +75,7 @@ def binary_thresholding(
 
 
 def _get_mask(data, mask, val_intensity, otsu, foreground):
-    """ Helper function to get the data binary segmented into a mask """
+    """Helper function to get the data binary segmented into a mask"""
     if otsu:
         # get the intensity value based on Otsu
         val_intensity = filters.threshold_otsu(data)

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -26,25 +26,24 @@ import cupyx
 import numpy as np
 import nvtx
 
+from httomolib.cuda_kernels import load_cuda_module
+
 __all__ = [
-    'fresnel_filter',
-    'paganin_filter',
-    'retrieve_phase',
+    "fresnel_filter",
+    "paganin_filter",
+    "retrieve_phase",
 ]
 
 # Define constants used in phase retrieval method
 BOLTZMANN_CONSTANT = 1.3806488e-16  # [erg/k]
-SPEED_OF_LIGHT = 299792458e+2  # [cm/s]
+SPEED_OF_LIGHT = 299792458e2  # [cm/s]
 PI = 3.14159265359
 PLANCK_CONSTANT = 6.58211928e-19  # [keV*s]
 
 
 # CuPy implementation of Fresnel filter ported from Savu
 def fresnel_filter(
-    mat: cp.ndarray,
-    pattern: str,
-    ratio: float,
-    apply_log: bool = True
+    mat: cp.ndarray, pattern: str, ratio: float, apply_log: bool = True
 ) -> cp.ndarray:
     """
     Apply Fresnel filter.
@@ -74,8 +73,10 @@ def fresnel_filter(
         mat = cp.expand_dims(mat, 0)
 
     if mat.ndim != 3:
-        raise ValueError(f"Invalid number of dimensions in data: {mat.ndim},"
-                         " please provide a stack of 2D projections.")
+        raise ValueError(
+            f"Invalid number of dimensions in data: {mat.ndim},"
+            " please provide a stack of 2D projections."
+        )
 
     if apply_log is True:
         mat = -cp.log(mat)
@@ -105,23 +106,23 @@ def fresnel_filter(
     for i in range(mat.shape[0]):
         if pattern == "PROJECTION":
             top_drop = 10  # To remove the time stamp in some data
-            mat_pad = cp.pad(mat[i][top_drop:], (
-                (pad_width + top_drop, pad_width), (pad_width, pad_width)),
-                mode="edge")
+            mat_pad = cp.pad(
+                mat[i][top_drop:],
+                ((pad_width + top_drop, pad_width), (pad_width, pad_width)),
+                mode="edge",
+            )
             win_pad = cp.pad(window, pad_width, mode="edge")
-            mat_dec = \
-                cp.fft.ifft2(cp.fft.fft2(mat_pad) / cp.fft.ifftshift(win_pad))
+            mat_dec = cp.fft.ifft2(cp.fft.fft2(mat_pad) / cp.fft.ifftshift(win_pad))
             mat_dec = cp.real(
-                mat_dec[pad_width:pad_width + nrow, pad_width:pad_width + ncol])
+                mat_dec[pad_width : pad_width + nrow, pad_width : pad_width + ncol]
+            )
             res[i] = mat_dec
         else:
-            mat_pad = \
-                cp.pad(mat[i], ((0, 0), (pad_width, pad_width)), mode='edge')
-            win_pad = cp.pad(window, ((0, 0), (pad_width, pad_width)),
-                             mode="edge")
+            mat_pad = cp.pad(mat[i], ((0, 0), (pad_width, pad_width)), mode="edge")
+            win_pad = cp.pad(window, ((0, 0), (pad_width, pad_width)), mode="edge")
             mat_fft = cp.fft.fftshift(cp.fft.fft(mat_pad), axes=1) / win_pad
             mat_dec = cp.fft.ifft(cp.fft.ifftshift(mat_fft, axes=1))
-            mat_dec = cp.real(mat_dec[:, pad_width:pad_width + ncol])
+            mat_dec = cp.real(mat_dec[:, pad_width : pad_width + ncol])
             res[i] = mat_dec
 
     if apply_log is True:
@@ -137,10 +138,10 @@ def _make_window(height, width, ratio, pattern):
         ulist = (1.0 * cp.arange(0, width) - center_wid) / width
         vlist = (1.0 * cp.arange(0, height) - center_hei) / height
         u, v = cp.meshgrid(ulist, vlist)
-        win2d = 1.0 + ratio * (u ** 2 + v ** 2)
+        win2d = 1.0 + ratio * (u**2 + v**2)
     else:
         ulist = (1.0 * cp.arange(0, width) - center_wid) / width
-        win1d = 1.0 + ratio * ulist ** 2
+        win1d = 1.0 + ratio * ulist**2
         win2d = cp.tile(win1d, (height, 1))
 
     return win2d
@@ -157,8 +158,8 @@ def paganin_filter(
     resolution: float = 1.28,
     pad_y: int = 100,
     pad_x: int = 100,
-    pad_method: str = 'edge',
-    increment: float = 0.0
+    pad_method: str = "edge",
+    increment: float = 0.0,
 ) -> cp.ndarray:
     """
     Apply Paganin filter (for denoising or contrast enhancement) to
@@ -203,8 +204,10 @@ def paganin_filter(
         data = cp.expand_dims(data, 0)
 
     if data.ndim != 3:
-        raise ValueError(f"Invalid number of dimensions in data: {data.ndim},"
-                         " please provide a stack of 2D projections.")
+        raise ValueError(
+            f"Invalid number of dimensions in data: {data.ndim},"
+            " please provide a stack of 2D projections."
+        )
 
     # Setup various values for the filter
     _, height, width = data.shape
@@ -219,43 +222,12 @@ def paganin_filter(
 
     # Define the paganin filter, taking into account the padding that will be
     # applied to the projections (if any)
-    
-    # Using RawKernel her as indexing is direct and it avoids a lot of temporaries
+
+    # Using raw kernel her as indexing is direct and it avoids a lot of temporaries
     # and tiny kernels
-    kernel = cp.RawKernel(r"""
-    #include <cupy/complex.cuh>
+    module = load_cuda_module("paganin_filter_gen")
+    kernel = module.get_function("paganin_filter_gen")
 
-    extern "C" __global__
-    void paganin_filter_gen(int width1, int height1, float resolution,
-                            float wavelength, float distance, float ratio,
-                            complex<float>* filtercomplex) {
-        int px = threadIdx.x + blockIdx.x * blockDim.x;
-        int py = threadIdx.y + blockIdx.y * blockDim.y;
-        if (px >= width1) return;
-        if (py >= height1) return;
-
-        float dpx = 1.0f / (width1 * resolution);
-        float dpy = 1.0f / (height1 * resolution);
-        int centerx = (width1 + 1) / 2 - 1;
-        int centery = (height1 + 1) / 2 - 1;
-
-        float pxx = (px - centerx) * dpx;
-        float pyy = (py - centery) * dpy;
-        float pd = (pxx*pxx + pyy*pyy) * wavelength * distance * 3.1415926535897932384626433832795f;
-        float filter1 = 1.0f + ratio * pd;
-
-        complex<float> value = 1.0f / complex<float>(filter1, filter1);
-
-        // ifftshifting positions
-        int xshift = (width1 + 1) / 2;
-        int yshift = (height1 + 1) / 2;
-        int outX = (px + xshift) % width1;
-        int outY = (py + yshift) % height1;
-
-        filtercomplex[outY * width1 + outX] = value;
-    }
-    """, "paganin_filter_gen")
-    
     # Apply padding to all the 2D projections
     # Note: this takes considerable time on GPU...
     data = cp.pad(data, ((0, 0), (pad_y, pad_y), (pad_x, pad_x)), mode=pad_method)
@@ -293,21 +265,26 @@ def paganin_filter(
 
     # avoid normalising in both directions - we include multiplier in the post_kernel
     data = cupyx.scipy.fft.fft2(data, axes=(-2, -1), overwrite_x=True, norm="backward")
-    
+
     # prepare filter here, while the GPU is busy with the FFT
     filtercomplex = cp.empty((height1, width1), dtype=np.complex64)
     bx = 16
     by = 8
     gx = (width1 + bx - 1) // bx
     gy = (height1 + by - 1) // by
-    kernel(grid=(gx, gy, 1), block=(bx, by, 1), 
-        args=(cp.int32(width1), 
-                cp.int32(height1), 
-                cp.float32(resolution), 
-                cp.float32(wavelength), 
-                cp.float32(distance), 
-                cp.float32(ratio), 
-                filtercomplex))
+    kernel(
+        grid=(gx, gy, 1),
+        block=(bx, by, 1),
+        args=(
+            cp.int32(width1),
+            cp.int32(height1),
+            cp.float32(resolution),
+            cp.float32(wavelength),
+            cp.float32(distance),
+            cp.float32(ratio),
+            filtercomplex,
+        ),
+    )
     data *= filtercomplex
 
     data = cupyx.scipy.fft.ifft2(data, axes=(-2, -1), overwrite_x=True, norm="forward")
@@ -319,10 +296,14 @@ def paganin_filter(
         name="paganin_post_proc",
         no_return=True,
     )
-    fft_scale = 1.0/(data.shape[1] * data.shape[2])
+    fft_scale = 1.0 / (data.shape[1] * data.shape[2])
     res = cp.empty((data.shape[0], height, width), dtype=np.float32)
     post_kernel(
-        data[:, pad_y : pad_y + height, pad_x : pad_x + width], np.float32(increment), np.float32(ratio), np.float32(fft_scale), res
+        data[:, pad_y : pad_y + height, pad_x : pad_x + width],
+        np.float32(increment),
+        np.float32(ratio),
+        np.float32(fft_scale),
+        res,
     )
 
     return res
@@ -334,10 +315,10 @@ def paganin_filter(
 def retrieve_phase(
     tomo: cp.ndarray,
     pixel_size: float = 1e-4,
-    dist: float = 50.,
-    energy: float = 20.,
+    dist: float = 50.0,
+    energy: float = 20.0,
     alpha: float = 1e-3,
-    pad: bool = True
+    pad: bool = True,
 ) -> cp.ndarray:
     """
     Perform single-step phase retrieval from phase-contrast measurements
@@ -369,8 +350,10 @@ def retrieve_phase(
         tomo = cp.expand_dims(tomo, 0)
 
     if tomo.ndim != 3:
-        raise ValueError(f"Invalid number of dimensions in data: {tomo.ndim},"
-                         " please provide a stack of 2D projections.")
+        raise ValueError(
+            f"Invalid number of dimensions in data: {tomo.ndim},"
+            " please provide a stack of 2D projections."
+        )
 
     # New dimensions and pad value after padding.
     py, pz, val = _calc_pad(tomo, pixel_size, dist, energy, pad)
@@ -380,10 +363,9 @@ def retrieve_phase(
     w2 = _reciprocal_grid(pixel_size, dy + 2 * py, dz + 2 * pz)
 
     # Filter in Fourier space.
-    phase_filter = cp.fft.fftshift(
-        _paganin_filter_factor(energy, dist, alpha, w2))
+    phase_filter = cp.fft.fftshift(_paganin_filter_factor(energy, dist, alpha, w2))
 
-    prj = cp.full((dy + 2*py, dz + 2*pz), val, dtype=cp.float32)
+    prj = cp.full((dy + 2 * py, dz + 2 * pz), val, dtype=cp.float32)
 
     # Apply phase retrieval
     return _retrieve_phase(tomo, phase_filter, py, pz, prj, pad)
@@ -395,17 +377,17 @@ def _retrieve_phase(
     px: int,
     py: int,
     prj: cp.ndarray,
-    pad: bool
+    pad: bool,
 ) -> cp.ndarray:
     _, dy, dz = tomo.shape
     num_projs = tomo.shape[0]
     normalized_phase_filter = phase_filter / phase_filter.max()
     for m in range(num_projs):
-        prj[px:dy + px, py:dz + py] = tomo[m]
+        prj[px : dy + px, py : dz + py] = tomo[m]
         prj[:px] = prj[px]
-        prj[-px:] = prj[-px-1]
+        prj[-px:] = prj[-px - 1]
         prj[:, :py] = prj[:, py][:, cp.newaxis]
-        prj[:, -py:] = prj[:, -py-1][:, cp.newaxis]
+        prj[:, -py:] = prj[:, -py - 1][:, cp.newaxis]
         # TomoPy has its own 2D FFT implementations
         # https://github.com/tomopy/tomopy/blob/master/source/tomopy/util/misc.py,
         # the NumPy equivalent in CuPy has been used as an alternative
@@ -414,13 +396,14 @@ def _retrieve_phase(
         fproj *= normalized_phase_filter
         proj = cp.real(cp.fft.ifft2(fproj))
         if pad:
-            proj = proj[px:dy + px, py:dz + py]
+            proj = proj[px : dy + px, py : dz + py]
         tomo[m] = proj
     return tomo
 
 
-def _calc_pad(tomo: cp.ndarray, pixel_size: float, dist: float, energy: float,
-              pad: bool) -> tuple[int, int, float]:
+def _calc_pad(
+    tomo: cp.ndarray, pixel_size: float, dist: float, energy: float, pad: bool
+) -> tuple[int, int, float]:
     """
     Calculate new dimensions and pad value after padding.
 
@@ -460,14 +443,14 @@ def _wavelength(energy: float) -> float:
     return 2 * PI * PLANCK_CONSTANT * SPEED_OF_LIGHT / energy
 
 
-def _paganin_filter_factor(energy: float, dist: float, alpha: float,
-                           w2: cp.ndarray) -> cp.ndarray:
+def _paganin_filter_factor(
+    energy: float, dist: float, alpha: float, w2: cp.ndarray
+) -> cp.ndarray:
     return 1 / (_wavelength(energy) * dist * w2 / (4 * PI) + alpha)
 
 
-def _calc_pad_width(dim: int, pixel_size: float, wavelength: float,
-                    dist: float) -> int:
-    pad_pix = cp.ceil(PI * wavelength * dist / pixel_size ** 2)
+def _calc_pad_width(dim: int, pixel_size: float, wavelength: float, dist: float) -> int:
+    pad_pix = cp.ceil(PI * wavelength * dist / pixel_size**2)
     return int((pow(2, cp.ceil(cp.log2(dim + pad_pix))) - dim) * 0.5)
 
 
@@ -504,10 +487,10 @@ def _reciprocal_grid(pixel_size: float, nx: int, ny: int) -> cp.ndarray:
     #
     # When `ufunc.outer` is supported in CuPy, this code can be updated
     # accordingly.
-    grid = cp.empty((len(indx),len(indy)))
+    grid = cp.empty((len(indx), len(indy)))
     for i in range(len(indx)):
         for j in range(len(indy)):
-            grid[i,j] = cp.add(indx[i], indy[j])
+            grid[i, j] = cp.add(indx[i], indy[j])
     return grid
 
 
@@ -531,4 +514,4 @@ def _reciprocal_coord(pixel_size: float, num_grid: int) -> cp.ndarray:
     n = num_grid - 1
     rc = cp.arange(-n, num_grid, 2, dtype=cp.float32)
     rc *= 0.5 / (n * pixel_size)
-    return  rc
+    return rc

--- a/httomolib/prep/stripe.py
+++ b/httomolib/prep/stripe.py
@@ -27,8 +27,8 @@ import numpy as np
 import nvtx
 
 __all__ = [
-    'remove_stripe_based_sorting',
-    'remove_stripe_ti',
+    "remove_stripe_based_sorting",
+    "remove_stripe_ti",
 ]
 
 # TODO: port 'remove_all_stripe', 'remove_large_stripe' and 'remove_dead_stripe'

--- a/httomolib/recon/algorithm.py
+++ b/httomolib/recon/algorithm.py
@@ -28,10 +28,13 @@ import cupyx
 import numpy as np
 import nvtx
 
+from httomolib.cuda_kernels import load_cuda_module
+
 __all__ = [
     'reconstruct_tomobar',
     'reconstruct_tomopy_astra',
 ]
+
 
 ## %%%%%%%%%%%%%%%%%%%%%%% ToMoBAR reconstruction %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 @nvtx.annotate()
@@ -66,7 +69,7 @@ def reconstruct_tomobar(
     """
     from tomobar.methodsDIR import RecToolsDIR
     from tomobar.supp.astraOP import AstraTools3D
-        
+
     if center is None:
         center = data.shape[2] // 2 # making a crude guess
     if objsize is None:
@@ -88,11 +91,13 @@ def reconstruct_tomobar(
         # is neither C nor F contiguous. 
         # So we have to make it C-contiguous first
         data = cp.ascontiguousarray(cp.swapaxes(data, 0, 1))
-        reconstruction = Atools.backprojCuPy(data) # backproject the filtered data while keeping data on the GPU
+        reconstruction = Atools.backprojCuPy(
+            data
+        )  # backproject the filtered data while keeping data on the GPU
         cp._default_memory_pool.free_all_blocks()
         # ------------------------------------------------------- #
-
     return reconstruction
+
 
 @nvtx.annotate()
 def _filtersinc3D_cupy(projection3D):
@@ -104,111 +109,42 @@ def _filtersinc3D_cupy(projection3D):
     Returns:
         ndarray: a CuPy array of filtered projection data.
     """
-    
+
     # prepearing a ramp-like filter to apply to every projection
-    filter_prep = cp.RawKernel(
-        r"""
-        #define MY_PI 3.1415926535897932384626433832795f
-
-        extern "C" __global__ 
-        void generate_filtersinc(float a, float* f, int n, float multiplier) {
-            int tid = threadIdx.x;    // using only one block
-
-            float dw = 2 * MY_PI / n;
-
-            extern __shared__ char smem_raw[];
-            float* smem = reinterpret_cast<float*>(smem_raw);
-
-            // from: cp.linalg.pinv(rd_c)
-            // pseudo-inverse of vector is x/sum(x**2),
-            // so we need to compute sum(x**2) in shared memory
-            float sum = 0.0;
-            for (int i = tid; i < n; i += blockDim.x) {
-                float w = -MY_PI  + i * dw;
-                float rn2 = a * w / 2.0f;
-                sum += rn2 * rn2;
-            }
-            
-            smem[tid] = sum;
-            __syncthreads();
-            int nt = blockDim.x;
-            int c = nt;
-            while (c > 1) {
-                int half = c / 2;
-                if (tid < half) {
-                    smem[tid] += smem[c - tid - 1];
-                }
-                __syncthreads();
-                c = c - half;
-            }
-            float sum_aw2_sqr = smem[0];
-
-            // cp.dot(rn2, cp.linalg.pinv(rd_c))**2
-            // now we can calclate the dot product, preparing summing in shared memory
-            float dot_partial = 0.0;
-            for (int i = tid; i < n; i += blockDim.x) {
-                float w = -MY_PI  + i * dw;
-                float rd = a*w/2.0f;
-                float rn2 = sin(rd);
-                
-                dot_partial += rn2 * rd / sum_aw2_sqr;
-            }
-                
-            // now reduce dot_partial to full dot-product result
-            smem[tid] = dot_partial;
-            __syncthreads();
-            c = nt;
-            while (c > 1) {
-                int half = c / 2;
-                if (tid < half) {
-                    smem[tid] += smem[c - tid - 1];
-                }
-                __syncthreads();
-                c = c - half;
-            }
-            float dotprod_sqr = smem[0] * smem[0];
-
-            // now compute actual result
-            for (int i = tid; i < n; i += blockDim.x) {
-                float w = -MY_PI  + i * dw;
-                float rd = a*w/2.0f;
-                float rn2 = sin(rd);
-                float rn1 = abs(2.0/a*rn2);
-                float r = rn1 * dotprod_sqr;
-
-                
-                // write to ifftshifted positions
-                int shift = n / 2;
-                int outidx = (i + shift) % n;
-
-                // apply multiplier here - which does FFT scaling too
-                f[outidx] = r * multiplier;
-            }
-        }
-        """, "generate_filtersinc"
-    )
-
+    module = load_cuda_module("generate_filtersync")
+    filter_prep = module.get_function("generate_filtersinc")
 
     # since the fft is complex-to-complex, it makes a copy of the real input array anyway,
     # so we do that copy here explicitly, and then do everything in-place
     projection3D = projection3D.astype(cp.complex64)
-    projection3D = cupyx.scipy.fft.fft2(projection3D, axes=(1, 2), overwrite_x=True, norm="backward")
-    
+    projection3D = cupyx.scipy.fft.fft2(
+        projection3D, axes=(1, 2), overwrite_x=True, norm="backward"
+    )
+
     # generating the filter here so we can schedule/allocate while FFT is keeping the GPU busy
     a = 1.1
     (projectionsNum, DetectorsLengthV, DetectorsLengthH) = cp.shape(projection3D)
-    f = cp.empty((1,1,DetectorsLengthH), dtype=np.float32)
+    f = cp.empty((1, 1, DetectorsLengthH), dtype=np.float32)
     bx = 256
     # because FFT is linear, we can apply the FFT scaling + multiplier in the filter
-    multiplier = 1.0/projectionsNum/DetectorsLengthV/DetectorsLengthH
-    filter_prep(grid=(1, 1, 1), block=(bx, 1, 1), 
-                args=(cp.float32(a), f, np.int32(DetectorsLengthH), np.float32(multiplier)),
-                shared_mem=bx*4)
+    multiplier = 1.0 / projectionsNum / DetectorsLengthV / DetectorsLengthH
+    filter_prep(
+        grid=(1, 1, 1),
+        block=(bx, 1, 1),
+        args=(cp.float32(a), f, np.int32(DetectorsLengthH), np.float32(multiplier)),
+        shared_mem=bx * 4,
+    )
     # actual filtering
     projection3D *= f
-    
+
     # avoid normalising here - we have included that in the filter
-    return cp.real(cupyx.scipy.fft.ifft2(projection3D, axes=(1, 2), overwrite_x=True, norm="forward"))
+    return cp.real(
+        cupyx.scipy.fft.ifft2(
+            projection3D, axes=(1, 2), overwrite_x=True, norm="forward"
+        )
+    )
+
+
 ## %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 
 
@@ -241,7 +177,7 @@ def reconstruct_tomopy_astra(
     iterations : int, optional
         The number of iterations if the iterative algorithm is chosen.
     proj_type : str, optional
-        Define projector type, e.g., "cuda" for "FBP_CUDA" algorithm 
+        Define projector type, e.g., "cuda" for "FBP_CUDA" algorithm
         or "linear" for "FBP" (CPU) algorithm, see more available ASTRA projectors.
     gpu_id : int, optional
         A GPU device index to perform operation on.
@@ -267,4 +203,6 @@ def reconstruct_tomopy_astra(
                            ncore=ncore,)
     
     return reconstruction
+
+
 ## %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -34,13 +34,13 @@ from cupyx.scipy.ndimage import gaussian_filter, shift
 from httomolib.cuda_kernels import load_cuda_module
 
 __all__ = [
-    'find_center_vo_cupy',
-    'find_center_360',
+    "find_center_vo",
+    "find_center_360",
 ]
 
 
 @nvtx.annotate()
-def find_center_vo_cupy(
+def find_center_vo(
     data: cp.ndarray,
     ind: int = None,
     smin: int = -50,
@@ -48,7 +48,7 @@ def find_center_vo_cupy(
     srad: int = 6,
     step: int = 0.25,
     ratio: int = 0.5,
-    drop: int = 20
+    drop: int = 20,
 ) -> float:
     """
     Find rotation axis location using Nghia Vo's method. See the paper
@@ -65,7 +65,7 @@ def find_center_vo_cupy(
         the sinogram.
     smax : int, optional
         Coarse search radius. Reference to the horizontal center of
-        the sinogram.        
+        the sinogram.
     srad : float, optional
         Fine search radius.
     step : float, optional
@@ -81,10 +81,7 @@ def find_center_vo_cupy(
     float
         Rotation axis location.
     """
-    return _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop)
 
-
-def _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop):
     if data.ndim == 2:
         data = cp.expand_dims(data, 1)
         ind = 0
@@ -94,7 +91,7 @@ def _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop):
     if ind is None:
         ind = height // 2
         if height > 10:
-            _sino = cp.mean(data[:, ind - 5: ind + 5, :], axis=1)
+            _sino = cp.mean(data[:, ind - 5 : ind + 5, :], axis=1)
         else:
             _sino = data[:, ind, :]
     else:
@@ -104,7 +101,7 @@ def _find_center_vo_gpu(data, ind, smin, smax, srad, step, ratio, drop):
         _sino_cs = gaussian_filter(_sino, (3, 1), mode="reflect")
     with nvtx.annotate("gaussian_filter_2", color="green"):
         _sino_fs = gaussian_filter(_sino, (2, 2), mode="reflect")
-    
+
     if _sino.shape[0] * _sino.shape[1] > 4e6:
         # data is large, so downsample it before performing search for
         # centre of rotation
@@ -136,7 +133,7 @@ def _search_coarse(sino, smin, smax, ratio, drop):
     list_shift = 2.0 * (list_cor - cen_fliplr)
     list_metric = cp.empty(list_shift.shape, dtype=cp.float32)
     _calculate_metric(list_shift, sino, flip_sino, comp_sino, mask, list_metric)
-    
+
     minpos = cp.argmin(list_metric)
     if minpos == 0:
         print("WARNING!!!Global minimum is out of searching range")
@@ -155,78 +152,18 @@ def _search_fine(sino, srad, step, init_cen, ratio, drop):
     flip_sino = cp.ascontiguousarray(cp.fliplr(sino))
     comp_sino = cp.ascontiguousarray(cp.flipud(sino))
     mask = _create_mask(2 * nrow, ncol, 0.5 * ratio * ncol, drop)
-    
+
     cen_fliplr = (ncol - 1.0) / 2.0
-    srad = max(min(abs(float(srad)), ncol/4.0), 1.0)
+    srad = max(min(abs(float(srad)), ncol / 4.0), 1.0)
     step = max(min(abs(step), srad), 0.1)
     init_cen = max(min(init_cen, ncol - srad - 1), srad)
     list_cor = init_cen + cp.arange(-srad, srad + step, step, dtype=np.float32)
     list_shift = 2.0 * (list_cor - cen_fliplr)
     list_metric = cp.empty(list_shift.shape, dtype="float32")
-    
+
     _calculate_metric(list_shift, sino, flip_sino, comp_sino, mask, out=list_metric)
     cor = list_cor[cp.argmin(list_metric)]
     return cor
-
-
-GENERATE_MASK_KERNEL = cp.RawKernel(
-    r"""
-extern "C" __global__
-void generate_mask(const int ncol, const int nrow, const int cen_col,
-                    const int cen_row, const float du, const float dv,
-                    const float radius, const float drop, unsigned short* mask) {
-    int i = blockDim.x * blockIdx.x + threadIdx.x;
-    int j = blockDim.y * blockIdx.y + threadIdx.y;
-    
-    if (j >= nrow || i >= ncol)
-        return;
-    
-    int pos = __float2int_ru(((j - cen_row) * dv / radius) / du);
-    int pos1 = -pos + cen_col;
-    int pos2 = pos + cen_col;
-
-    if (pos1 > pos2) {
-        int temp = pos1;
-        pos1 = pos2;
-        pos2 = temp;
-        if (pos1 >= ncol) {
-            pos1 = ncol -1;
-        }
-        if (pos2 < 0) {
-            pos2 = 0;
-        }
-    }
-    else {
-        if (pos1 < 0) {
-            pos1 = 0;
-        }
-        if (pos2 >= ncol) {
-            pos2 = ncol -1;
-        }
-    }
-
-    short outval = (pos1 <= i && i <= pos2) ? 1 : 0;
-
-    // mask[cen_row - drop: cen_row + drop + 1, :] = 0
-    if (j >= cen_row - drop && j <= cen_row + drop) {
-        outval = 0;
-    }
-    // mask[:, cen_col - 1: cen_col + 2] = 0
-    if (i >= cen_col - 1 && i <= cen_col + 1) {
-        outval = 0;
-    }
-    
-    // write to ifft-shifted positions
-    int ishift = (ncol + 1) / 2;
-    int jshift = (nrow + 1) / 2;
-    int outi = (i + ishift) % ncol;
-    int outj = (j + jshift) % nrow;
-
-    mask[outj * ncol + outi] = outval;
-}
-""",
-    "generate_mask",
-)
 
 
 @nvtx.annotate()
@@ -237,12 +174,11 @@ def _create_mask(nrow, ncol, radius, drop):
     cen_col = int(math.ceil(ncol / 2.0) - 1)
     drop = min([drop, int(math.ceil(0.05 * nrow))])
 
-
     block_x = 16
     block_y = 8
     block_dims = (block_x, block_y)
     grid_x = (ncol + block_x - 1) // block_x
-    grid_y = (nrow  + block_y - 1) // block_y
+    grid_y = (nrow + block_y - 1) // block_y
     grid_dims = (grid_x, grid_y)
     mask = cp.empty((nrow, ncol), dtype="uint16")
     params = (
@@ -256,7 +192,9 @@ def _create_mask(nrow, ncol, radius, drop):
         cp.float32(drop),
         mask,
     )
-    GENERATE_MASK_KERNEL(grid_dims, block_dims, params)
+    module = load_cuda_module("generate_mask")
+    kernel = module.get_function("generate_mask")
+    kernel(grid_dims, block_dims, params)
     return mask
 
 
@@ -275,71 +213,27 @@ def _calculate_metric(list_shift, sino1, sino2, sino3, mask, out):
     assert sino2.dtype == cp.float32, "sino1 must be float32"
     assert sino3.dtype == cp.float32, "sino1 must be float32"
     assert out.dtype == cp.float32, "sino1 must be float32"
-    assert sino2.flags['C_CONTIGUOUS'], "sino2 must be C-contiguous"
-    assert sino3.flags['C_CONTIGUOUS'], "sino3 must be C-contiguous"
-    assert list_shift.flags['C_CONTIGUOUS'], "list_shift must be C-contiguous"
+    assert sino2.flags["C_CONTIGUOUS"], "sino2 must be C-contiguous"
+    assert sino3.flags["C_CONTIGUOUS"], "sino3 must be C-contiguous"
+    assert list_shift.flags["C_CONTIGUOUS"], "list_shift must be C-contiguous"
     nshifts = list_shift.shape[0]
     na1 = sino1.shape[0]
     na2 = sino2.shape[0]
-    mat = cp.empty((nshifts, na1+na2, sino2.shape[1]), dtype=cp.float32)
-    
-    
-    # first, handle the integer shifts without spline in a raw kernel, 
-    # and shift in the sino3 one accordingly
-    shift_whole_shifts = cp.RawKernel(r"""
-        #include <cupy/complex.cuh>
+    mat = cp.empty((nshifts, na1 + na2, sino2.shape[1]), dtype=cp.float32)
 
-        extern "C" __global__
-        void shift_whole_shifts(const float* sino2, const float* sino3, 
-                                const float* __restrict__ list_shift,
-                                float* mat, int nx, int nymat) {
-           int xid = threadIdx.x + blockIdx.x * blockDim.x;
-           int yid = blockIdx.y;
-           int zid = blockIdx.z;
-           int ny = gridDim.y;
-           
-           if (xid >= nx) return;
-           
-           float shift_col = list_shift[zid];
-           float int_part = 0.0;
-           float frac_part = modf(shift_col, &int_part);
-           if (abs(frac_part) > 1e-5f) {
-                // we have a floating point shift, so we only roll in 
-                // sino3, but we leave the rest for later using scipy
-                int shift_int = shift_col >= 0.0 ? int(ceil(shift_col)) : int(floor(shift_col));
-                if (shift_int >= 0 && xid < shift_int) {
-                   mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
-                } 
-                if (shift_int < 0 && xid >= nx+shift_int) {
-                   mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
-                }
-           } else {
-                // we have an integer shift, so we can roll in directly
-                // by indexing
-                int shift_int = int(shift_col);
-                if (shift_int >= 0) {
-                    if (xid >= shift_int) {
-                        mat[zid * nymat * nx + yid * nx + xid] = sino2[yid * nx + xid-shift_int];
-                    } else {
-                        mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
-                    }
-                } else {
-                    if (xid < nx+shift_int) {
-                        mat[zid * nymat * nx + yid * nx + xid] = sino2[yid * nx + xid-shift_int];
-                    } else {
-                        mat[zid * nymat * nx + yid * nx + xid] = sino3[yid * nx + xid];
-                    }
-                }
-           }
-        }
-    """, name="shift_whole_shifts")
+    # first, handle the integer shifts without spline in a raw kernel,
+    # and shift in the sino3 one accordingly
+    module = load_cuda_module("center_360_shifts")
+    shift_whole_shifts = module.get_function("shift_whole_shifts")
 
     bx = 128
     gx = (sino3.shape[1] + bx - 1) // bx
-    shift_whole_shifts(grid=(gx, na2, list_shift.shape[0]),
-                       block=(bx, 1, 1),
-                       args=(sino2, sino3, list_shift, mat[:,na1:,:], sino3.shape[1], na1+na2))
-    
+    shift_whole_shifts(
+        grid=(gx, na2, list_shift.shape[0]),
+        block=(bx, 1, 1),
+        args=(sino2, sino3, list_shift, mat[:, na1:, :], sino3.shape[1], na1 + na2),
+    )
+
     # now we can only look at the spline shifting, the rest is done
     list_shift_host = cp.asnumpy(list_shift)
     for i in range(list_shift_host.shape[0]):
@@ -352,64 +246,17 @@ def _calculate_metric(list_shift, sino1, sino2, sino3, mask, out):
             else:
                 mat[i, na1:, :shift_int] = shifted[:, :shift_int]
 
-        
     # stack and transform
-    mat[:,:na1,:] = sino1
-    cp.abs(cp.fft.fft2(mat, axes=(1,2)), out=mat)
+    mat[:, :na1, :] = sino1
+    cp.abs(cp.fft.fft2(mat, axes=(1, 2)), out=mat)
     mat *= mask
-    cp.mean(mat, axis=(1,2), out=out)
-
-
-
-
-DOWNSAMPLE_SINO_KERNEL = cp.RawKernel(
-    r"""
-    extern "C" __global__
-    void downsample_sino(float* sino, int dx, int dz, int level,
-                         float* out) {
-        // use shared memory to store the values used to "merge" columns of the
-        // sinogram in the downsampling process
-        extern __shared__ float downsampled_vals[];
-        unsigned int binsize, i, j, k, orig_ind, out_ind, output_bin_no;
-        i = blockDim.x * blockIdx.x + threadIdx.x;
-        j = 0;
-        k = blockDim.y * blockIdx.y + threadIdx.y;
-        orig_ind = (k * dz) + i;
-        binsize = 1 << level;
-        unsigned int dz_downsampled = __float2uint_rd(
-            fdividef(__uint2float_rd(dz), __uint2float_rd(binsize)));
-        unsigned int i_downsampled = __float2uint_rd(
-            fdividef(__uint2float_rd(i), __uint2float_rd(binsize)));
-        if (orig_ind < dx * dz) {
-            output_bin_no =  __float2uint_rd(
-                fdividef(__uint2float_rd(i), __uint2float_rd(binsize))
-            );
-            out_ind = (k * dz_downsampled) + i_downsampled;
-            downsampled_vals[threadIdx.y * 8 + threadIdx.x] = sino[orig_ind] / __uint2float_rd(binsize);
-            // synchronise threads within thread-block so that it's guaranteed
-            // that all the required values have been copied into shared memeory
-            // to then sum and save in the downsampled output
-            __syncthreads();
-            // arbitrarily use the "beginning thread" in each "lot" of pixels
-            // for downsampling to then save the desired value in the
-            // downsampled output array
-            if (i % 4 == 0) {
-                out[out_ind] = downsampled_vals[threadIdx.y * 8 + threadIdx.x] +
-                    downsampled_vals[threadIdx.y * 8 + threadIdx.x + 1] +
-                    downsampled_vals[threadIdx.y * 8 + threadIdx.x + 2] +
-                    downsampled_vals[threadIdx.y * 8 + threadIdx.x + 3];
-            }
-        }
-    }
-    """,
-    "downsample_sino",
-)
+    cp.mean(mat, axis=(1, 2), out=out)
 
 
 @nvtx.annotate()
 def _downsample(sino, level, axis):
     assert sino.dtype == cp.float32, "single precision floating point input required"
-    assert sino.flags['C_CONTIGUOUS'], "list_shift must be C-contiguous"
+    assert sino.flags["C_CONTIGUOUS"], "list_shift must be C-contiguous"
 
     dx, dz = sino.shape
     # Determine the new size, dim, of the downsampled dimension
@@ -429,11 +276,13 @@ def _downsample(sino, level, axis):
     # memeory per thread-block
     shared_mem_bytes = 64
     params = (sino, dx, dz, level, downsampled_data)
-    DOWNSAMPLE_SINO_KERNEL(grid_dims, block_dims, params, shared_mem=shared_mem_bytes)
+    module = load_cuda_module("downsample_sino")
+    kernel = module.get_function("downsample_sino")
+    kernel(grid_dims, block_dims, params, shared_mem=shared_mem_bytes)
     return downsampled_data
 
 
-#--- Center of rotation (COR) estimation method ---#
+# --- Center of rotation (COR) estimation method ---#
 @nvtx.annotate()
 def find_center_360(
     data: cp.ndarray,
@@ -442,7 +291,7 @@ def find_center_360(
     side: set = None,
     denoise: bool = True,
     norm: bool = False,
-    use_overlap: bool = False
+    use_overlap: bool = False,
 ) -> Tuple[float, float, int, float]:
     """
     Find the center-of-rotation (COR) in a 360-degree scan with offset COR use
@@ -456,7 +305,7 @@ def find_center_360(
     data : cp.ndarray
         3D tomographic data as a Cupy array.
     ind : int, optional
-        Index of the slice to be used for estimate the CoR and the overlap.        
+        Index of the slice to be used for estimate the CoR and the overlap.
     win_width : int, optional
         Window width used for finding the overlap area.
     side : {None, 0, 1}, optional
@@ -492,17 +341,17 @@ def find_center_360(
 
     # this method works with a 360-degree sinogram.
     if ind is None:
-        _sino = data[:, 0, :]        
+        _sino = data[:, 0, :]
     else:
         _sino = data[:, ind, :]
-    
-    
+
     (nrow, ncol) = _sino.shape
     nrow_180 = nrow // 2 + 1
     sino_top = _sino[0:nrow_180, :]
     sino_bot = cp.fliplr(_sino[-nrow_180:, :])
     (overlap, side, overlap_position) = _find_overlap(
-        sino_top, sino_bot, win_width, side, denoise, norm, use_overlap)
+        sino_top, sino_bot, win_width, side, denoise, norm, use_overlap
+    )
     if side == 0:
         cor = overlap / 2.0 - 1.0
     else:
@@ -511,8 +360,9 @@ def find_center_360(
     return cp.float32(cor), cp.float32(overlap), side, cp.float32(overlap_position)
 
 
-def _find_overlap(mat1, mat2, win_width, side=None, denoise=True, norm=False,
-                 use_overlap=False):
+def _find_overlap(
+    mat1, mat2, win_width, side=None, denoise=True, norm=False, use_overlap=False
+):
     """
     Find the overlap area and overlap side between two images (Ref. [1]) where
     the overlap side referring to the first image.
@@ -553,22 +403,50 @@ def _find_overlap(mat1, mat2, win_width, side=None, denoise=True, norm=False,
     win_width = int(np.clip(win_width, 6, min(ncol1, ncol2) // 2))
 
     if side == 1:
-        (list_metric, offset) = _search_overlap(mat1, mat2, win_width, side=side,
-                                               denoise=denoise, norm=norm, use_overlap=use_overlap)
+        (list_metric, offset) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=side,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
         overlap_position = _calculate_curvature(list_metric)[1]
         overlap_position += offset
         overlap = ncol1 - overlap_position + win_width // 2
     elif side == 0:
-        (list_metric, offset) = _search_overlap(mat1, mat2, win_width, side=side,
-                                               denoise=denoise, norm=norm, use_overlap=use_overlap)
+        (list_metric, offset) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=side,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
         overlap_position = _calculate_curvature(list_metric)[1]
         overlap_position += offset
         overlap = overlap_position + win_width // 2
     else:
-        (list_metric1, offset1) = _search_overlap(mat1, mat2, win_width, side=1,
-                                                 denoise=denoise, norm=norm, use_overlap=use_overlap)
-        (list_metric2, offset2) = _search_overlap(mat1, mat2, win_width, side=0,
-                                                 denoise=denoise, norm=norm, use_overlap=use_overlap)
+        (list_metric1, offset1) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=1,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
+        (list_metric2, offset2) = _search_overlap(
+            mat1,
+            mat2,
+            win_width,
+            side=0,
+            denoise=denoise,
+            norm=norm,
+            use_overlap=use_overlap,
+        )
 
         (curvature1, overlap_position1) = _calculate_curvature(list_metric1)
         overlap_position1 += offset1
@@ -587,10 +465,10 @@ def _find_overlap(mat1, mat2, win_width, side=None, denoise=True, norm=False,
     return overlap, side, overlap_position
 
 
-
 @nvtx.annotate()
-def _search_overlap(mat1, mat2, win_width, side, denoise=True, norm=False,
-                   use_overlap=False):
+def _search_overlap(
+    mat1, mat2, win_width, side, denoise=True, norm=False, use_overlap=False
+):
     """
     Calculate the correlation metrics between a rectangular region, defined
     by the window width, on the utmost left/right side of image 2 and the
@@ -627,12 +505,12 @@ def _search_overlap(mat1, mat2, win_width, side, denoise=True, norm=False,
     if denoise is True:
         # note: the filtering makes the output contiguous
         with nvtx.annotate("denoise_filter", color="green"):
-            mat1 = cpndi.gaussian_filter(mat1, (2, 2), mode='reflect')
-            mat2 = cpndi.gaussian_filter(mat2, (2, 2), mode='reflect')
+            mat1 = cpndi.gaussian_filter(mat1, (2, 2), mode="reflect")
+            mat2 = cpndi.gaussian_filter(mat2, (2, 2), mode="reflect")
     else:
         mat1 = cp.ascontiguousarray(mat1, dtype=cp.float32)
         mat2 = cp.ascontiguousarray(mat2, dtype=cp.float32)
-    
+
     (nrow1, ncol1) = mat1.shape
     (nrow2, ncol2) = mat2.shape
 
@@ -643,9 +521,8 @@ def _search_overlap(mat1, mat2, win_width, side, denoise=True, norm=False,
     offset = win_width // 2
     win_width = 2 * offset  # Make it even
 
-    list_metric = _calc_metrics(mat1, mat2, 
-                                     win_width, side, use_overlap, norm)
-    
+    list_metric = _calc_metrics(mat1, mat2, win_width, side, use_overlap, norm)
+
     min_metric = cp.min(list_metric)
     if min_metric != 0.0:
         list_metric /= min_metric
@@ -653,41 +530,48 @@ def _search_overlap(mat1, mat2, win_width, side, denoise=True, norm=False,
     return list_metric, offset
 
 
-_calc_metrics_module = load_cuda_module("calc_metrics", 
-                                        name_expressions=[
-                                            "calc_metrics_kernel<false, false>",
-                                            "calc_metrics_kernel<true, false>",
-                                            "calc_metrics_kernel<false, true>",
-                                            "calc_metrics_kernel<true, true>"],
-                                        options=('--maxrregcount=32',))
+_calc_metrics_module = load_cuda_module(
+    "calc_metrics",
+    name_expressions=[
+        "calc_metrics_kernel<false, false>",
+        "calc_metrics_kernel<true, false>",
+        "calc_metrics_kernel<false, true>",
+        "calc_metrics_kernel<true, true>",
+    ],
+    options=("--maxrregcount=32",),
+)
+
 
 @nvtx.annotate()
-def _calc_metrics(mat1, mat2, 
-                      win_width,  side, use_overlap, norm):
+def _calc_metrics(mat1, mat2, win_width, side, use_overlap, norm):
     assert mat1.dtype == cp.float32, "only float32 supported"
     assert mat2.dtype == cp.float32, "only float32 supported"
     assert mat1.shape[0] == mat2.shape[0]
     assert mat1.flags.c_contiguous, "only contiguos arrays supported"
     assert mat2.flags.c_contiguous, "only contiguos arrays supported"
-    
+
     num_pos = mat1.shape[1] - win_width
     list_metric = cp.empty(num_pos, dtype=cp.float32)
 
-    args=(mat1, 
-          np.int32(mat1.strides[0]/mat1.strides[1]),
-          mat2, 
-          np.int32(mat2.strides[0]/mat2.strides[1]),
-          np.int32(win_width),
-          np.int32(mat1.shape[0]), 
-          np.int32(side), 
-          list_metric)
-    block=(128, 1, 1)
-    grid=(1, np.int32(num_pos), 1)
-    smem=block[0]*4*6 if use_overlap else block[0]*4*3
-    bool2str = lambda x: 'true' if x is True else 'false'
-    calc_metrics = _calc_metrics_module.get_function(f"calc_metrics_kernel<{bool2str(norm)}, {bool2str(use_overlap)}>")
+    args = (
+        mat1,
+        np.int32(mat1.strides[0] / mat1.strides[1]),
+        mat2,
+        np.int32(mat2.strides[0] / mat2.strides[1]),
+        np.int32(win_width),
+        np.int32(mat1.shape[0]),
+        np.int32(side),
+        list_metric,
+    )
+    block = (128, 1, 1)
+    grid = (1, np.int32(num_pos), 1)
+    smem = block[0] * 4 * 6 if use_overlap else block[0] * 4 * 3
+    bool2str = lambda x: "true" if x is True else "false"
+    calc_metrics = _calc_metrics_module.get_function(
+        f"calc_metrics_kernel<{bool2str(norm)}, {bool2str(use_overlap)}>"
+    )
     calc_metrics(grid=grid, block=block, args=args, shared_mem=smem)
-        
+
     return list_metric
 
 
@@ -715,14 +599,14 @@ def _calculate_curvature(list_metric):
     min_pos = int(np.clip(min_metric_idx, radi, num_metric - radi - 1))
 
     # work mostly on CPU here - we have very small arrays here
-    list1 = cp.asnumpy(list_metric[min_pos - radi:min_pos + radi + 1])
+    list1 = cp.asnumpy(list_metric[min_pos - radi : min_pos + radi + 1])
     afact1 = np.polyfit(np.arange(0, 2 * radi + 1), list1, 2)[0]
-    list2 = cp.asnumpy(list_metric[min_pos - 1:min_pos + 2])
+    list2 = cp.asnumpy(list_metric[min_pos - 1 : min_pos + 2])
     (afact2, bfact2, _) = np.polyfit(np.arange(min_pos - 1, min_pos + 2), list2, 2)
 
     curvature = np.abs(afact1)
     if afact2 != 0.0:
-        num = - bfact2 / (2 * afact2)
+        num = -bfact2 / (2 * afact2)
         if (num >= min_pos - 1) and (num <= min_pos + 1):
             min_pos = num
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,9 +1,9 @@
 import cupy as cp
 import numpy as np
 from cupy.testing import assert_allclose
-from httomolib.prep.normalize import normalize_cupy
+from httomolib.prep.normalize import normalize as normalize_cupy
 from httomolib.prep.stripe import remove_stripe_based_sorting as remove_stripes
-from httomolib.recon.rotation import find_center_vo_cupy
+from httomolib.recon.rotation import find_center_vo as find_center_vo_cupy
 from tomopy.prep.normalize import normalize
 from tomopy.prep.stripe import remove_stripe_based_sorting
 from tomopy.recon.rotation import find_center_vo
@@ -23,11 +23,11 @@ def test_cpu_vs_gpu(host_data, host_flats, host_darks, ensure_clean_memory):
     darks = cp.asarray(host_darks)
 
     #: Normalize the data first
-    data_normalize_cupy = normalize_cupy(data, flats, darks, cutoff=15.0)
-    assert data_normalize_cupy.shape == (180, 128, 160)
+    data_normalize = normalize_cupy(data, flats, darks, cutoff=15.0)
+    assert data_normalize.shape == (180, 128, 160)
 
     #: Now do the stripes removal
-    corrected_data = remove_stripes(data_normalize_cupy)
+    corrected_data = remove_stripes(data_normalize)
 
     #: Apply Fresnel/Paganin filtering
 
@@ -50,7 +50,7 @@ def test_cpu_vs_gpu(host_data, host_flats, host_darks, ensure_clean_memory):
 
     #: TEST 2: check if the data is normalized correctly for both CPU and GPU
     np.testing.assert_almost_equal(
-        cp.mean(data_normalize_cupy), np.mean(tomopy_data), decimal=3
+        cp.mean(data_normalize), np.mean(tomopy_data), decimal=3
     )
 
     #: TEST 3: check if the stripes are removed correctly for both CPU and GPU

--- a/tests/test_prep/test_alignment.py
+++ b/tests/test_prep/test_alignment.py
@@ -4,8 +4,8 @@ import cupy as cp
 import numpy as np
 import pytest
 from httomolib.prep.alignment import (
-    distortion_correction_proj_cupy,
-    distortion_correction_proj_discorpy_cupy,
+    distortion_correction_proj,
+    distortion_correction_proj_discorpy,
 )
 from imageio.v2 import imread
 from numpy.testing import assert_allclose
@@ -23,7 +23,7 @@ from numpy.testing import assert_allclose
 )
 @pytest.mark.parametrize(
     "implementation",
-    [distortion_correction_proj_cupy, distortion_correction_proj_discorpy_cupy],
+    [distortion_correction_proj, distortion_correction_proj_discorpy],
     ids=["cupy", "tomopy"],
 )
 def test_correct_distortion(

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -5,39 +5,27 @@ import numpy as np
 import pytest
 
 from numpy.testing import assert_allclose, assert_equal
-from httomolib.prep.normalize import normalize_cupy, normalize_raw_cuda
+from httomolib.prep.normalize import normalize
 from cupy.cuda import nvtx
 
 
 @cp.testing.gpu
-def test_normalize_cupy_1D_raises(data, flats, darks, ensure_clean_memory):
+def test_normalize_1D_raises(data, flats, darks, ensure_clean_memory):
     _data_1d = cp.ones(10)
 
     #: data cannot be a 1D array
     with pytest.raises(ValueError):
-        normalize_cupy(_data_1d, flats, darks)
+        normalize(_data_1d, flats, darks)
 
     #: flats cannot be a 1D array
     with pytest.raises(ValueError):
-        normalize_cupy(data, _data_1d, darks)
+        normalize(data, _data_1d, darks)
 
 
 @cp.testing.gpu
-def test_normalize_raw_cuda_1D_raises(data, flats, darks, ensure_clean_memory):
-    _data_1d = cp.ones(10)
-
-    #: data cannot be a 1D array
-    with pytest.raises(ValueError):
-        normalize_raw_cuda(_data_1d, flats, darks)
-
-    with pytest.raises(ValueError):
-        normalize_raw_cuda(data, _data_1d, _data_1d)
-
-
-@cp.testing.gpu
-def test_normalize_cupy(data, flats, darks, ensure_clean_memory):
-    # --- testing normalize_cupy  ---#
-    data_normalize = normalize_cupy(cp.copy(data), flats, darks, minus_log=True).get()
+def test_normalize(data, flats, darks, ensure_clean_memory):
+    # --- testing normalize  ---#
+    data_normalize = normalize(cp.copy(data), flats, darks, minus_log=True).get()
 
     assert data_normalize.dtype == np.float32
 
@@ -45,38 +33,11 @@ def test_normalize_cupy(data, flats, darks, ensure_clean_memory):
     assert_allclose(np.mean(data_normalize, axis=(1, 2)).sum(), 52.064465, rtol=1e-06)
     assert_allclose(np.median(data_normalize), 0.01723744, rtol=1e-06)
     assert_allclose(np.std(data_normalize), 0.524382, rtol=1e-06)
-
-
-@cp.testing.gpu
-def test_normalize_raw_cuda(data, flats, darks, ensure_clean_memory):
-    # --- testing normalize_raw_cuda  ---#
-    data_normalize = normalize_raw_cuda(data, flats, darks, minus_log=True).get()
-
-    assert data_normalize.dtype == np.float32
-
-    assert_allclose(np.mean(data_normalize), 0.2892469, rtol=1e-06)
-    assert_allclose(np.mean(data_normalize, axis=(1, 2)).sum(), 52.064465, rtol=1e-06)
-    assert_allclose(np.median(data_normalize), 0.01723744, rtol=1e-06)
-    assert_allclose(np.std(data_normalize), 0.524382, rtol=1e-06)
-
-
-@cp.testing.gpu
-def test_normalize_raw_cuda_vs_normalize_cupy(data, ensure_clean_memory):
-    flats = cp.ones(shape=data.shape) + 100
-    darks = cp.random.randint(low=64, high=117, size=data.shape, dtype=cp.uint16)
-    assert_equal(
-        normalize_cupy(
-            cp.copy(data), flats, darks, minus_log=True, nonnegativity=True
-        ).get(),
-        normalize_raw_cuda(
-            data, flats, darks, minus_log=True, nonnegativity=True
-        ).get(),
-    )
 
 
 @cp.testing.gpu
 @pytest.mark.perf
-def test_normalize_cupy_performance(ensure_clean_memory):
+def test_normalize_performance(ensure_clean_memory):
     # Note: low/high and size values taken from sample2_medium.yaml real run
     data_host = np.random.randint(
         low=7515, high=37624, size=(1801, 5, 2560), dtype=np.uint16
@@ -93,7 +54,7 @@ def test_normalize_cupy_performance(ensure_clean_memory):
 
     # run code and time it
     # do a cold run for warmup
-    normalize_cupy(
+    normalize(
         cp.copy(data),
         flats,
         darks,
@@ -107,7 +68,7 @@ def test_normalize_cupy_performance(ensure_clean_memory):
     start = time.perf_counter_ns()
     nvtx.RangePush("Core")
     for _ in range(10):
-        normalize_cupy(
+        normalize(
             cp.copy(data),
             flats,
             darks,
@@ -115,38 +76,6 @@ def test_normalize_cupy_performance(ensure_clean_memory):
             minus_log=True,
             nonnegativity=False,
             remove_nans=False,
-        )
-    nvtx.RangePop()
-    dev.synchronize()
-    end = time.perf_counter_ns()
-    duration_ms = float(end - start) * 1e-6 / 10
-
-    assert "performance in ms" == duration_ms
-
-
-@cp.testing.gpu
-@pytest.mark.perf
-def test_normalize_raw_cuda_performance(ensure_clean_memory):
-    data = cp.random.randint(
-        low=7515, high=37624, size=(1801, 5, 2560), dtype=cp.uint16
-    )
-    flats = cp.random.randint(
-        low=43397, high=52324, size=(50, 5, 2560), dtype=cp.uint16
-    )
-    darks = cp.random.randint(low=64, high=117, size=(20, 5, 2560), dtype=cp.uint16)
-
-    # run code and time it
-    # do a cold run for warmup
-    normalize_raw_cuda(
-        data, flats, darks, cutoff=10.0, minus_log=True, nonnegativity=True
-    )
-    dev = cp.cuda.Device()
-    dev.synchronize()
-    start = time.perf_counter_ns()
-    nvtx.RangePush("Core")
-    for _ in range(10):
-        normalize_raw_cuda(
-            data, flats, darks, cutoff=10.0, minus_log=True, nonnegativity=True
         )
     nvtx.RangePop()
     dev.synchronize()

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -3,7 +3,7 @@ import cupy as cp
 from cupy.cuda import nvtx
 import numpy as np
 import pytest
-from httomolib.prep.normalize import normalize_cupy
+from httomolib.prep.normalize import normalize
 from httomolib.prep.stripe import (
     remove_stripe_based_sorting,
     remove_stripe_ti,
@@ -14,7 +14,7 @@ from numpy.testing import assert_allclose
 @cp.testing.gpu
 def test_remove_stripe_ti_on_data(data, flats, darks):
     # --- testing the CuPy implementation from TomoCupy ---#
-    data = normalize_cupy(data, flats, darks, cutoff=10, minus_log=True)
+    data = normalize(data, flats, darks, cutoff=10, minus_log=True)
     data_after_stripe_removal = remove_stripe_ti(cp.copy(data)).get()
 
     data = None  #: free up GPU memory
@@ -45,7 +45,7 @@ def test_remove_stripe_ti_numpy_vs_cupy_on_random_data():
         cp.copy(cp.asarray(host_data, dtype=cp.float32))
     ).get()
 
-    assert_allclose(np.sum(corrected_data), np.sum(corrected_host_data))
+    assert_allclose(np.sum(corrected_data), np.sum(corrected_host_data), rtol=1e-6)
     assert_allclose(
         np.median(corrected_data), np.median(corrected_host_data), rtol=1e-6
     )
@@ -54,7 +54,7 @@ def test_remove_stripe_ti_numpy_vs_cupy_on_random_data():
 @cp.testing.gpu
 def test_stripe_removal_sorting_cupy(data, flats, darks):
     # --- testing the CuPy port of TomoPy's implementation ---#
-    data = normalize_cupy(data, flats, darks, cutoff=10, minus_log=True)
+    data = normalize(data, flats, darks, cutoff=10, minus_log=True)
     corrected_data = remove_stripe_based_sorting(data).get()
 
     data = None  #: free up GPU memory

--- a/tests/test_recon/test_algorithm.py
+++ b/tests/test_recon/test_algorithm.py
@@ -1,6 +1,6 @@
 import cupy as cp
 import numpy as np
-from httomolib.prep.normalize import normalize_cupy
+from httomolib.prep.normalize import normalize as normalize_cupy
 from httomolib.recon.algorithm import (
     reconstruct_tomobar,
     reconstruct_tomopy_astra,

--- a/tests/test_recon/test_recon.py
+++ b/tests/test_recon/test_recon.py
@@ -1,17 +1,17 @@
 import cupy as cp
 import numpy as np
 import pytest
-from httomolib.prep.normalize import normalize_cupy
-from httomolib.recon.rotation import find_center_360, find_center_vo_cupy
+from httomolib.prep.normalize import normalize
+from httomolib.recon.rotation import find_center_360, find_center_vo
 from numpy.testing import assert_allclose
 
 
 @cp.testing.gpu
-def test_find_center_vo_cupy(data, flats, darks):
-    data = normalize_cupy(data, flats, darks)
+def test_find_center_vo(data, flats, darks):
+    data = normalize(data, flats, darks)
 
     #--- testing the center of rotation on tomo_standard ---#
-    cor = find_center_vo_cupy(data)
+    cor = find_center_vo(data)
 
     data = None #: free up GPU memory
     assert_allclose(cor, 79.5)
@@ -21,9 +21,9 @@ def test_find_center_vo_cupy(data, flats, darks):
 
 
 @cp.testing.gpu
-def test_find_center_vo_cupy_ones(ensure_clean_memory):
+def test_find_center_vo_ones(ensure_clean_memory):
     mat = cp.ones(shape=(103, 450, 230), dtype=cp.float32)
-    cor = find_center_vo_cupy(mat)
+    cor = find_center_vo(mat)
 
     assert_allclose(cor, 59.0)
     mat = None #: free up GPU memory

--- a/tests/test_recon/test_rotation.py
+++ b/tests/test_recon/test_rotation.py
@@ -3,18 +3,18 @@ import cupy as cp
 from cupy.cuda import nvtx
 import numpy as np
 import pytest
-from httomolib.prep.normalize import normalize_cupy
-from httomolib.recon.rotation import find_center_360, find_center_vo_cupy
+from httomolib.prep.normalize import normalize
+from httomolib.recon.rotation import find_center_360, find_center_vo
 from numpy.testing import assert_allclose
 from .rotation_cpu_reference import find_center_360_numpy
 
 
 @cp.testing.gpu
-def test_find_center_vo_cupy(data, flats, darks):
-    data = normalize_cupy(data, flats, darks)
+def test_find_center_vo(data, flats, darks):
+    data = normalize(data, flats, darks)
 
     # --- testing the center of rotation on tomo_standard ---#
-    cor = find_center_vo_cupy(data)
+    cor = find_center_vo(data)
 
     data = None  #: free up GPU memory
     assert_allclose(cor, 79.5)
@@ -24,9 +24,9 @@ def test_find_center_vo_cupy(data, flats, darks):
 
 
 @cp.testing.gpu
-def test_find_center_vo_cupy_ones(ensure_clean_memory):
+def test_find_center_vo_ones(ensure_clean_memory):
     mat = cp.ones(shape=(103, 450, 230), dtype=cp.float32)
-    cor = find_center_vo_cupy(mat)
+    cor = find_center_vo(mat)
 
     assert_allclose(cor, 59.0)
     mat = None  #: free up GPU memory
@@ -34,18 +34,18 @@ def test_find_center_vo_cupy_ones(ensure_clean_memory):
 
 @cp.testing.gpu
 @pytest.mark.perf
-def test_find_center_vo_cupy_performance():
+def test_find_center_vo_performance():
     dev = cp.cuda.Device()
     data_host = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0
     data = cp.asarray(data_host, dtype=np.float32)
-    
+
     # cold run first
-    find_center_vo_cupy(data)
+    find_center_vo(data)
 
     start = time.perf_counter_ns()
     nvtx.RangePush("Core")
     for _ in range(10):
-        find_center_vo_cupy(data)
+        find_center_vo(data)
     nvtx.RangePop()
     dev.synchronize()
     duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
@@ -56,7 +56,7 @@ def test_find_center_vo_cupy_performance():
 @cp.testing.gpu
 def test_find_center_360_ones():
     mat = cp.ones(shape=(100, 100, 100), dtype=cp.float32)
-    
+
     (cor, overlap, side, overlap_position) = find_center_360(mat)
 
     assert_allclose(cor, 5.0)
@@ -69,7 +69,7 @@ def test_find_center_360_ones():
 def test_find_center_360_data(data):
     eps = 1e-5
     (cor, overlap, side, overlap_pos) = find_center_360(data, norm=True, denoise=False)
-    
+
     assert_allclose(cor, 132.45317, rtol=eps)
     assert_allclose(overlap, 53.093666, rtol=eps)
     assert side == 1
@@ -79,13 +79,13 @@ def test_find_center_360_data(data):
     assert cor.dtype == np.float32
     assert overlap.dtype == np.float32
 
+
 @cp.testing.gpu
 def test_find_center_360_1D_raises(data):
-    
     #: 360-degree sinogram must be a 3d array
     with pytest.raises(ValueError):
         find_center_360(data[:, 10, :])
-    
+
     with pytest.raises(ValueError):
         find_center_360(cp.ones(10))
 
@@ -103,21 +103,22 @@ def test_find_center_360_unity(ensure_clean_memory, xp, norm, overlap, denoise, 
     data = xp.asarray(data)
 
     if xp.__name__ == "numpy":
-        (cor, overlap, side, overlap_pos) = find_center_360_numpy(data, use_overlap=overlap, 
-                                                            norm=norm, denoise=denoise, 
-                                                            side=side)
+        (cor, overlap, side, overlap_pos) = find_center_360_numpy(
+            data, use_overlap=overlap, norm=norm, denoise=denoise, side=side
+        )
     else:
-        (cor, overlap, side, overlap_pos) = find_center_360(data, use_overlap=overlap, 
-                                                            norm=norm, denoise=denoise, 
-                                                            side=side)
+        (cor, overlap, side, overlap_pos) = find_center_360(
+            data, use_overlap=overlap, norm=norm, denoise=denoise, side=side
+        )
 
     return xp.asarray([cor, overlap, side, overlap_pos])
-    
 
 
 @pytest.mark.perf
 def test_find_center_360_performance(ensure_clean_memory):
-    data = cp.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
+    data = (
+        cp.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0 + 0.001
+    )
 
     # cold run
     find_center_360(data, use_overlap=True, norm=True, denoise=True)
@@ -132,11 +133,7 @@ def test_find_center_360_performance(ensure_clean_memory):
         find_center_360(data, use_overlap=True, norm=True, denoise=True)
     nvtx.RangePop()
     dev.synchronize()
-    
+
     duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
-    
+
     assert "performance in ms" == duration_ms
-
-
-
-        


### PR DESCRIPTION
This renames all methods to remove the `_cupy` suffix, removes redundant methods, and factors out the raw kernels into separate `.cu` files for readability. 

Additionally, it reformats all files using the black reformatter / linter.