### PR TITLE
Fixing median filter indexing: integer overflow

### DIFF
--- a/httomolib/cuda_kernels/median_kernel.cu
+++ b/httomolib/cuda_kernels/median_kernel.cu
@@ -15,15 +15,15 @@ __global__ void median_general_kernel(const Type *in, Type *out, float dif,
 
   int counter = 0;
   for (int i_m = -radius; i_m <= radius; i_m++) {
-    int i1 = i + i_m;
+    long long i1 = i + i_m;   // using long long to avoid integer overflows
     if ((i1 < 0) || (i1 >= N))
       i1 = i;
     for (int j_m = -radius; j_m <= radius; j_m++) {
-      int j1 = j + j_m;
+      long long j1 = j + j_m;
       if ((j1 < 0) || (j1 >= M))
         j1 = j;
       for (int k_m = -radius; k_m <= radius; k_m++) {
-        int k1 = k + k_m;
+        long long k1 = k + k_m;
         if ((k1 < 0) || (k1 >= Z))
           k1 = k;
         ValVec[counter] = in[i1 + N * j1 + N * M * k1];
@@ -44,12 +44,13 @@ __global__ void median_general_kernel(const Type *in, Type *out, float dif,
   }
 
   /* perform median filtration */
+  long long index = static_cast<long long>(i) + N * static_cast<long long>(j) + N * M * static_cast<long long>(k);
   if (dif == 0.0f)
-    out[i + N * j + N * M * k] = ValVec[midpoint];
+    out[index] = ValVec[midpoint];
   else {
     /* perform dezingering */
-    Type in_value = in[i + N * j + N * M * k];
-    out[i + N * j + N * M * k] =
+    Type in_value = in[index];
+    out[index] =
         fabsf(in_value - ValVec[midpoint]) >= dif ? ValVec[midpoint] : in_value;
   }
 }

--- a/httomolib/misc/corr.py
+++ b/httomolib/misc/corr.py
@@ -94,7 +94,7 @@ def median_filter3d(
     grid_z = dz
     grid_dims = (grid_x, grid_y, grid_z)
 
-    params = (data, out, dif, dz, dy, dx, dx * dy * dz)
+    params = (data, out, dif, dz, dy, dx)
 
     median3d(grid_dims, block_dims, params)
 

--- a/tests/test_misc/test_corr.py
+++ b/tests/test_misc/test_corr.py
@@ -93,7 +93,7 @@ def test_median_filter3d(data):
 @pytest.mark.perf
 def test_median_filter3d_performance(ensure_clean_memory):
     dev = cp.cuda.Device()
-    data_host = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0
+    data_host = np.random.random_sample(size=(450, 2160, 2560)).astype(np.float32) * 2.0
     data = cp.asarray(data_host, dtype=cp.float32)
 
     # warm up


### PR DESCRIPTION
This is a bugfix PR to allow median filter to work with large input data. It was using `int` for calculating indices, which overflowed for large arrays. This switches to `long long`, which is 64bit wide. 

To test, the performance test has been adjusted for a size large enough to cause an overflow - without the fix, the performance test gives an illegal memory access exception.

Further, it removes an extra parameter that was passed to the kernel but not used.