### PR TITLE
Adds sino_360_to_180 method 

### DIFF
--- a/httomolib/__init__.py
+++ b/httomolib/__init__.py
@@ -1,6 +1,7 @@
 from httomolib.misc.corr import *
 from httomolib.misc.images import *
 from httomolib.misc.segm import *
+from httomolib.misc.morph import *
 from httomolib.prep.alignment import *
 from httomolib.prep.normalize import *
 from httomolib.prep.phase import *

--- a/httomolib/misc/morph.py
+++ b/httomolib/misc/morph.py
@@ -54,6 +54,9 @@ def sino_360_to_180(
     cp.ndarray
         Output 3D data.
     """
+    if data.ndim != 3:
+        raise ValueError("only 3D data is supported")
+    
     dx, dy, dz = data.shape
 
     overlap = int(np.round(overlap))

--- a/httomolib/misc/morph.py
+++ b/httomolib/misc/morph.py
@@ -62,6 +62,8 @@ def sino_360_to_180(
     overlap = int(np.round(overlap))
     if overlap >= dz:
         raise ValueError("overlap must be less than data.shape[2]")
+    if overlap < 0:
+        raise ValueError("only positive overlaps are allowed.")
 
     n = dx // 2
 

--- a/httomolib/misc/morph.py
+++ b/httomolib/misc/morph.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ---------------------------------------------------------------------------
+# Copyright 2023 Diamond Light Source Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------------
+# Created By  : Tomography Team at DLS <scientificsoftware@diamond.ac.uk>
+# Created Date: 23 March 2023
+# version ='0.1'
+# ---------------------------------------------------------------------------
+"""Module for data type morphing functions"""
+
+import cupy as cp
+import numpy as np
+import nvtx
+from typing import Literal
+
+__all__ = [
+    "sino_360_to_180",
+]
+
+
+@nvtx.annotate()
+def sino_360_to_180(
+    data: cp.ndarray, overlap: int = 0, rotation: Literal["left", "right"] = "left"
+) -> cp.ndarray:
+    """
+    Converts 0-360 degrees sinogram to a 0-180 sinogram.
+    If the number of projections in the input data is odd, the last projection
+    will be discarded.
+
+    Parameters
+    ----------
+    data : cp.ndarray
+        Input 3D data.
+    overlap : scalar, optional
+        Overlapping number of pixels.
+    rotation : string, optional
+        'left' if rotation center is close to the left of the
+        field-of-view, 'right' otherwise.
+    Returns
+    -------
+    cp.ndarray
+        Output 3D data.
+    """
+    dx, dy, dz = data.shape
+
+    overlap = int(np.round(overlap))
+    if overlap >= dz:
+        raise ValueError("overlap must be less than data.shape[2]")
+
+    n = dx // 2
+
+    out = cp.empty((n, dy, 2 * dz - overlap), dtype=data.dtype)
+
+    if rotation == "left":
+        weights = cp.linspace(0, 1.0, overlap)
+        out[:, :, -dz + overlap :] = data[:n, :, overlap:]
+        out[:, :, : dz - overlap] = data[n : 2 * n, :, overlap:][:, :, ::-1]
+        out[:, :, dz - overlap : dz] = (
+            weights * data[:n, :, :overlap]
+            + (weights * data[n : 2 * n, :, :overlap])[:, :, ::-1]
+        )
+    elif rotation == "right":
+        weights = cp.linspace(1.0, 0, overlap)
+        out[:, :, : dz - overlap] = data[:n, :, :-overlap]
+        out[:, :, -dz + overlap :] = data[n : 2 * n, :, :-overlap][:, :, ::-1]
+        out[:, :, dz - overlap : dz] = (
+            weights * data[:n, :, -overlap:]
+            + (weights * data[n : 2 * n, :, -overlap:])[:, :, ::-1]
+        )
+    else:
+        raise ValueError('rotation parameter must be either "left" or "right"')
+
+    return out

--- a/tests/test_misc/test_morph.py
+++ b/tests/test_misc/test_morph.py
@@ -17,7 +17,9 @@ def test_sino_360_to_180_unity(ensure_clean_memory, xp, overlap, rotation):
         pytest.skip("Skipping test due to bug in tomopy")
 
     np.random.seed(12345)
-    data_host = np.random.random_sample(size=(123, 54, 128)).astype(np.float32) * 200.0 - 100.0
+    data_host = (
+        np.random.random_sample(size=(123, 54, 128)).astype(np.float32) * 200.0 - 100.0
+    )
     data = xp.asarray(data_host)
 
     if xp.__name__ == "numpy":
@@ -43,6 +45,13 @@ def test_sino_360_to_180_invalid(ensure_clean_memory, overlap, rotation):
 
     with pytest.raises(ValueError):
         sino_360_to_180(data, overlap, rotation)
+
+
+@pytest.mark.parametrize("shape", [(10,), (10, 10)])
+@cp.testing.gpu
+def test_sino_360_to_180_wrong_dims(ensure_clean_memory, shape):
+    with pytest.raises(ValueError):
+        sino_360_to_180(cp.ones(shape, dtype=cp.float32))
 
 
 @pytest.mark.parametrize("rotation", ["left", "right"])

--- a/tests/test_misc/test_morph.py
+++ b/tests/test_misc/test_morph.py
@@ -1,0 +1,69 @@
+import time
+import cupy as cp
+import numpy as np
+from cupy.cuda import nvtx
+import pytest
+from tomopy.misc.morph import sino_360_to_180 as tomopy_sino_360_to_180
+from httomolib.misc.morph import sino_360_to_180
+
+
+@cp.testing.gpu
+@pytest.mark.parametrize("overlap", [0, 1, 3, 15, 32])
+@pytest.mark.parametrize("rotation", ["left", "right"])
+@cp.testing.numpy_cupy_allclose(rtol=1e-6)
+def test_sino_360_to_180_unity(ensure_clean_memory, xp, overlap, rotation):
+    # this combination has a bug in tomopy, so we'll skip it for now
+    if rotation == "right" and overlap == 0:
+        pytest.skip("Skipping test due to bug in tomopy")
+
+    np.random.seed(12345)
+    data_host = np.random.random_sample(size=(123, 54, 128)).astype(np.float32) * 200.0 - 100.0
+    data = xp.asarray(data_host)
+
+    if xp.__name__ == "numpy":
+        return tomopy_sino_360_to_180(data, overlap, rotation)
+    else:
+        return sino_360_to_180(data, overlap, rotation)
+
+
+@pytest.mark.parametrize(
+    "overlap, rotation",
+    [
+        (-10, "left"),
+        (110, "left"),
+        (-10, "right"),
+        (110, "right"),
+        (0, "invalid"),
+        (0, ""),
+    ],
+)
+@cp.testing.gpu
+def test_sino_360_to_180_invalid(ensure_clean_memory, overlap, rotation):
+    data = cp.ones((10, 10, 10), dtype=cp.float32)
+
+    with pytest.raises(ValueError):
+        sino_360_to_180(data, overlap, rotation)
+
+
+@pytest.mark.parametrize("rotation", ["left", "right"])
+@pytest.mark.perf
+@cp.testing.gpu
+def test_sino_360_to_180_performance(ensure_clean_memory, rotation):
+    # as this is just an index shuffling operation, the data itself doesn't matter
+    data = cp.ones((1801, 400, 2560), dtype=np.float32)
+
+    # do a cold run first
+    sino_360_to_180(data, overlap=32, rotation=rotation)
+
+    dev = cp.cuda.Device()
+    dev.synchronize()
+
+    start = time.perf_counter_ns()
+    nvtx.RangePush("Core")
+    for _ in range(10):
+        sino_360_to_180(data, overlap=32, rotation=rotation)
+    nvtx.RangePop()
+    dev.synchronize()
+    duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 10
+
+    assert "performance in ms" == duration_ms


### PR DESCRIPTION
This adds a cupy version of the `sino_360_to_180` method [from tomopy](https://github.com/tomopy/tomopy/blob/master/source/tomopy/misc/morph.py#L314). It tests it against tomopy in all parameter configurations, and also performs tests for invalid inputs. 

The performance test shows in GPU that the function is likely fast enough on V100 without further optimisations. It could possibly be accelerated further with a `RawKernel`, which can combine all the 3 lines of the algorithm and avoid the space for the `linspace` - at the expense of readability.

The performance tests show the following on the Hamilton cluster with V100:

- `rotation=left`: 24.3ms  (vs 2997ms with tomopy) 
- `rotation=right`: 21.1ms (vs 2826ms with tomopy)

So it is around **130x faster than tomopy**