### PR TITLE
real2complex FFT in find_center_vo: 191ms -> 130ms, large memory savings

### DIFF
--- a/httomolib/cuda_kernels/generate_mask.cu
+++ b/httomolib/cuda_kernels/generate_mask.cu
@@ -4,10 +4,14 @@ extern "C" __global__ void generate_mask(const int ncol, const int nrow,
                                          const float radius, const float drop,
                                          unsigned short *mask) {
   int i = blockDim.x * blockIdx.x + threadIdx.x;
-  int j = blockDim.y * blockIdx.y + threadIdx.y;
+  int j = blockIdx.y;
 
-  if (j >= nrow || i >= ncol)
+  if (i >= ncol/2+1)
     return;
+
+  // we only need to look at the right half as we're using a real2complex FFT
+  int outi = i;
+  i += ncol/2-1;
 
   int pos = __float2int_ru(((j - cen_row) * dv / radius) / du);
   int pos1 = -pos + cen_col;
@@ -43,11 +47,5 @@ extern "C" __global__ void generate_mask(const int ncol, const int nrow,
     outval = 0;
   }
 
-  // write to ifft-shifted positions
-  int ishift = (ncol + 1) / 2;
-  int jshift = (nrow + 1) / 2;
-  int outi = (i + ishift) % ncol;
-  int outj = (j + jshift) % nrow;
-
-  mask[outj * ncol + outi] = outval;
+  mask[j * (ncol/2+1) + outi] = outval;
 }

--- a/tests/test_recon/test_rotation.py
+++ b/tests/test_recon/test_rotation.py
@@ -32,6 +32,19 @@ def test_find_center_vo_ones(ensure_clean_memory):
     mat = None  #: free up GPU memory
 
 
+
+@cp.testing.gpu
+def test_find_center_vo_random(ensure_clean_memory):
+    np.random.seed(12345)
+    data_host = np.random.random_sample(size=(1801, 5, 2560)).astype(np.float32) * 2.0
+    data = cp.asarray(data_host, dtype=np.float32)
+
+    cent = find_center_vo(data)
+
+    assert_allclose(cent, 1246.75)
+
+
+
 @cp.testing.gpu
 @pytest.mark.perf
 def test_find_center_vo_performance():


### PR DESCRIPTION
This optimises the `find_center_vo` method by using a real-to-complex FFT instead. This reduces the runtime in the performance test from 191ms to 130ms. But more significantly, it drastically reduces the memory required for the function (only half the size for the FFT plan + no copy of the input data to complex needed).

It also required to re-write the mask generation kernel. It's symmetric - and only the right half is needed for consistent results. It has been tested with random data and everything is consistent with the previous implementation.