### PR TITLE
Memory estimation functions

### DIFF
--- a/doc/decorators.rst
+++ b/doc/decorators.rst
@@ -1,0 +1,96 @@
+Method Decorators
+=================
+
+All tomography methods exported by the ``httomolib`` package require to be decorated using one 
+of the ``method_all``, ``method_proj``, or ``method_sino`` decorators.
+These add the method to the global ``method_registry`` object, with information about their
+supported patterns, module location, parameters, GPU support, etc.
+See the relevant documentation about these methods in ``httomolib.decorator`` for a description
+of their parameters.
+
+All these decorators take a function as parameter to determine the maximum number of slices
+that the method can process given the amount of available memory on the GPU. 
+This function is passed using the ``calc_max_slices`` parameter - required for GPU methods (the default).
+
+Max Slices Calculation
+----------------------
+
+The ``calc_max_slices`` function must have the following signature::
+
+    def calc_max_slices(slice_dim: int,
+                        other_dims: Tuple[int, int],
+                        dtype: np.dtype,
+                        available_memory: int,
+                        **kwargs) -> int: ...
+
+The ``httomo`` package will call this function, passing in the dimension along which it will slice
+(``0`` for projection, ``1`` for sinogram), the other dimensions of the data array shape,
+the data type for the input, and the avaialble memory on the GPU for method execution.
+Additionally it passes all other parameters of the method in the ``kwargs`` argument, 
+which can be used by the function in case parameters determine the memory consumption.
+The function should calculate how many slices along the slicing dimension it can fit into the given memory.
+
+**Example (All Patterns):**
+
+The ``httomo`` package will have to determine the number of slices along the projection dimension
+it can fit, given the other two dimension sizes. For example:
+
+* ``data.shape`` is ``[x, 10, 20]``, and ``httomo`` needs to determine the value for ``x``
+* The data type for ``data`` is ``float32`` (which means 4 bytes are needed per element)
+* Assume the available free memory on the GPU is 14,450 bytes
+* It will call the function as::
+
+    max_slices = my_method.meta.calc_max_slices(0, (10, 20), np.float32(), 14450, **method_args)
+
+* The developer of the given method needs to provide this function implementation,
+  and it needs to calculate the maximum number of slices it can fit. 
+* Assuming that the method is very simple and does not need any local temporary memory,
+  requiring only space for the input and output array, it could be implemented as follows::
+
+    def _my_calc_max_slices(slice_dim: int,
+                            other_dims: Tuple[int, int],
+                            dtype: np.dtype,
+                            available_memory: int,
+                            **kwargs) -> int:
+        input_mem_per_slice = other_dims[0] * other_dims[1] * dtype.nbytes
+        output_mem_per_slice = input_mem_per_slice
+        max_slices = available_memory // (input_mem_per_slice + output_mem_per_slice)
+        return max_slices
+
+  (note that `//` denotes integer division, which rounds towards zero)
+* If the method needs extra memory internally, this should be taken into account in the implementation.
+  There are several methods in this respository which can serve as an example.
+* This is then passed to the decorator as follows::
+
+    @method_all(_my_calc_max_slices)
+    def my_method(data: cp.ndarray, ...):
+        ...
+* With the example data given above, the function would determine that 9 slices can fit:
+
+  * call ``calc_max_slices(0, (10, 20), np.float32(), 14450, **method_args)``
+  * ``input_mem_per_slice = 800``
+  * ``output_mem_per_slice = 800``
+  * => ``max_slices = 14450 // 1600 = 9``
+  
+Note also for methods that only support the sinogram or project patterns (a single pattern), 
+the ``method_proj`` or ``method_sino`` decorators can be used and the ``calc_max_slices`` 
+function signature simplifies, removing the ``slice_dim`` parameter.
+
+Max Slices Tests
+----------------
+
+In order to test that the slice calculation function is reflecting reality, each method has a 
+unit test implemented that verifies that the calculation is right (within bounds).
+That is, it tests that the estimated slices are between 80% and 100% of the actually used slices.
+These tests also help to keep the memory estimation functions in sync with the implementation.
+
+The strategy for testing is the other way around:
+
+* We first run the actual method, given a specific data set, and record the maximum memory actually
+  used by the method.
+* Then, retrospectively, we call the ``calc_max_slices`` estimator function and pass in this memory
+  as the ``available_memory`` argument. So we're asking the estimation function to assume that 
+  the memory availalbe is the actually used memory in the method call. 
+* The estimated number of slices should then be less or equal to the actual slices used earlier.
+* To make sure the function is not too conservative, we're checking that it returns at least 80%
+  of the slices that actually fit. 

--- a/examples/correct-distortion.py
+++ b/examples/correct-distortion.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import cupy as cp
-from httomolib.prep.alignment import distortion_correction_proj_cupy
+from httomolib.prep.alignment import distortion_correction_proj
 from imageio.v2 import imread, imwrite
 
 # Load image to be corrected
@@ -23,7 +23,7 @@ distortion_coeffs_file_path = data_folder / 'distortion-correction/distortion-co
 
 # Apply distortion correction
 corrected_images = \
-    distortion_correction_proj_cupy(im, distortion_coeffs_file_path, PREVIEW)
+    distortion_correction_proj(im, distortion_coeffs_file_path, PREVIEW)
 corrected_images = cp.squeeze(corrected_images)
 
 # Save corrected image if desired

--- a/examples/normalize-data.py
+++ b/examples/normalize-data.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import cupy as cp
 import numpy as np
-from httomolib.prep.normalize import normalize_cupy, normalize_raw_cuda
+from httomolib.prep.normalize import normalize
 
 # Load the projection data
 data_folder = Path("tests/test_data/")
@@ -16,4 +16,4 @@ host_darks = datafile['darks']
 data = cp.asarray(host_data)
 flats = cp.asarray(host_flats)
 darks = cp.asarray(host_darks)
-data = normalize_cupy(data, flats, darks, cutoff = 10, minus_log = True)
+data = normalize(data, flats, darks, cutoff = 10, minus_log = True)

--- a/examples/pipeline_preproc.py
+++ b/examples/pipeline_preproc.py
@@ -5,11 +5,11 @@ from pathlib import Path
 
 import cupy as cp
 import numpy as np
-from httomolib.prep.alignment import distortion_correction_proj_cupy
-from httomolib.prep.normalize import normalize_cupy
+from httomolib.prep.alignment import distortion_correction_proj
+from httomolib.prep.normalize import normalize
 from httomolib.prep.phase import paganin_filter
-from httomolib.prep.stripe import remove_stripe_based_sorting_cupy
-from httomolib.recon.rotation import find_center_vo_cupy
+from httomolib.prep.stripe import remove_stripe_based_sorting
+from httomolib.recon.rotation import find_center_vo
 
 data_folder = Path("tests/test_data/")
 
@@ -31,14 +31,14 @@ elapsed_time_total = 0.0
 # ---------------------------------------------------------------#
 print ("Finding the Center of Rotation for the reconstruction")
 start_time = timeit.default_timer()
-cor = find_center_vo_cupy(data)
+cor = find_center_vo(data)
 elapsed_time_01 = timeit.default_timer() - start_time
 print('elapsed time', elapsed_time_01)
 elapsed_time_total += elapsed_time_01
 # ---------------------------------------------------------------#
 print ("Applying normalisation and take a negative log")
 start_time = timeit.default_timer()
-data = normalize_cupy(data, flats, darks, 
+data = normalize(data, flats, darks, 
                       cutoff = 10, minus_log = True)
 elapsed_time_02 = timeit.default_timer() - start_time
 print('elapsed time', elapsed_time_02)
@@ -47,7 +47,7 @@ elapsed_time_total += elapsed_time_02
 print ("Applying ring removal")
 # TODO replace with remove all rings
 start_time = timeit.default_timer()
-destriped_data = remove_stripe_based_sorting_cupy(data)
+destriped_data = remove_stripe_based_sorting(data)
 elapsed_time_03 = timeit.default_timer() - start_time
 print('elapsed time', elapsed_time_03)
 elapsed_time_total += elapsed_time_03

--- a/httomolib/__init__.py
+++ b/httomolib/__init__.py
@@ -1,3 +1,4 @@
+from .decorator import *
 from httomolib.misc.corr import *
 from httomolib.misc.images import *
 from httomolib.misc.segm import *

--- a/httomolib/cuda_kernels/__init__.py
+++ b/httomolib/cuda_kernels/__init__.py
@@ -1,10 +1,10 @@
 import os
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 import cupy as cp
 
 
 def load_cuda_module(
-    file: str, name_expressions: List[str] = None, options: Tuple[str] = tuple()
+    file: str, name_expressions: Optional[List[str]] = None, options: Tuple[str, ...] = tuple()
 ) -> cp.RawModule:
     """Load a CUDA module file, i.e. a .cu file, from the file system,
     compile it, and return is as a CuPy RawModule for further

--- a/httomolib/decorator.py
+++ b/httomolib/decorator.py
@@ -1,0 +1,97 @@
+import inspect
+
+from typing import Callable, List, Literal, Tuple, Protocol
+import numpy as np
+from dataclasses import dataclass, field
+
+method_registry = dict()
+
+
+class MemoryFunction(Protocol):
+    """
+    A callable signature for a function to determine the maximum chunk size
+    supported given the chunking dimension,
+    the size of the other dimensions,
+    the data type,
+    and the available memory in bytes.
+    It takes the actual method parmaters as kwargs, which it may use if needed.
+
+    It returns the maximum size in slice_dim dimension that can be supported
+    within the given memory.
+    """
+
+    def __call__(
+        self,
+        slice_dim: int,
+        other_dims: Tuple[int, int],
+        dtype: np.dtype,
+        available_memory: int,
+        **kwargs,
+    ) -> int:
+        ...
+
+class MemorySinglePattern(Protocol):
+    """Signature for a function to calculate the max chunk size for a method that 
+       supports only one pattern. 
+       It avoids the slice_dim parameter, as that's redundant in that case
+       """
+    def __call__(self, other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int) -> int: ...
+
+@dataclass(frozen=True)
+class MethodMeta:
+    """Class for meta properties of a function"""
+
+    method_name: str
+    signature: inspect.Signature
+    module: List[str]
+    calc_max_slices: MemoryFunction
+    pattern: Literal["projection", "sinogram", "all"]
+    function: Callable
+    others: dict = field(default_factory=dict)
+
+    def __call__(self, *args, **kwargs):
+        return self.function(*args, **kwargs)
+
+
+def method(calc_max_slices: MemoryFunction, **others):
+    def _method(func):
+        pattern = others["pattern"] if "pattern" in others else "all"
+        func.meta = MethodMeta(
+            method_name=func.__name__,
+            signature=inspect.signature(func),
+            module=inspect.getmodule(func).__name__.split("."),
+            calc_max_slices=calc_max_slices,
+            pattern=pattern,
+            others=others,
+            function=func,
+        )
+
+        # register the method
+        lvl = method_registry
+        for m in func.meta.module:
+            if not m in lvl:
+                lvl[m] = dict()
+            lvl = lvl[m]
+        lvl[func.meta.method_name] = func.meta
+
+        return func
+
+    return _method
+
+
+def method_sino(calc_max_slices: MemorySinglePattern, **others):
+    
+    def _calc_max_slices(_, otherdims, dtype, available_memory, **others):
+        return calc_max_slices(otherdims, dtype, available_memory, **others)
+    
+    return method(calc_max_slices=_calc_max_slices, **others, pattern="sinogram")
+
+
+def method_proj(calc_max_slices: MemorySinglePattern, **others):
+    def _calc_max_slices(_, otherdims, dtype, available_memory, **others):
+        return calc_max_slices(otherdims, dtype, available_memory, **others)
+    
+    return method(calc_max_slices=_calc_max_slices, **others, pattern="projection")
+
+
+method_all = method

--- a/httomolib/decorator.py
+++ b/httomolib/decorator.py
@@ -30,12 +30,46 @@ class MemoryFunction(Protocol):
     ) -> int:
         ...
 
+
 class MemorySinglePattern(Protocol):
-    """Signature for a function to calculate the max chunk size for a method that 
-       supports only one pattern. 
-       It avoids the slice_dim parameter, as that's redundant in that case
-       """
-    def __call__(self, other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int) -> int: ...
+    """Signature for a function to calculate the max chunk size for a method that
+    supports only one pattern.
+    It avoids the slice_dim parameter, as that's redundant in that case
+    """
+
+    def __call__(
+        self,
+        other_dims: Tuple[int, int],
+        dtype: np.dtype,
+        available_memory: int,
+        **kwargs,
+    ) -> int:
+        ...
+
+
+def calc_max_slices_default(
+    slice_dim: int,
+    other_dims: Tuple[int, int],
+    dtype: np.dtype,
+    available_memory: int,
+    **kwargs,
+) -> int:
+    """Default function for calculating maximum slices, which simply assumes
+    space for input and output only is required, both with the same datatype,
+    and no temporaries."""
+
+    return available_memory // (np.prod(other_dims) * dtype.itemsize * 2)
+
+
+def calc_max_slices_single_pattern_default(
+    other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
+) -> int:
+    """Default function for calculating maximum slices, which simply assumes
+    space for input and output only is required, both with the same datatype,
+    and no temporaries."""
+
+    return calc_max_slices_default(0, other_dims, dtype, available_memory, **kwargs)
+
 
 @dataclass(frozen=True)
 class MethodMeta:
@@ -46,6 +80,8 @@ class MethodMeta:
     module: List[str]
     calc_max_slices: MemoryFunction
     pattern: Literal["projection", "sinogram", "all"]
+    cpu: bool
+    gpu: bool
     function: Callable
     others: dict = field(default_factory=dict)
 
@@ -53,15 +89,46 @@ class MethodMeta:
         return self.function(*args, **kwargs)
 
 
-def method(calc_max_slices: MemoryFunction, **others):
+def method(
+    calc_max_slices: MemoryFunction = calc_max_slices_default,
+    cpuonly=False,
+    cpugpu=False,
+    **others,
+):
+    """
+    Decorator for exported tomography methods, annotating the method with
+    a function to calculate the memory requirements as well as other properties.
+
+    Parameters
+    ----------
+    calc_max_slices: MemoryFunction, optional
+        Function to calculate how many slices can fit in the given GPU memory at max.
+        If not given, it assumes memory is only needed for input and output and no
+        temporaries is needed.
+        It is not used for CPU-only functions.
+    cpuonly: bool, optional
+        Marks the method as CPU only (default: False).
+    cpugpu: bool, optional
+        Marks the method as supporting both CPU and GPU input arrays (default: False).
+    pattern: string, optional
+        Sets the patterns supported by the method: 'sinogram', 'projection', 'all'. (default: 'all')
+    **other: dict, optional
+        Any other keyword arguments will be added to the meta info as a dictionary.
+    """
+
     def _method(func):
         pattern = others["pattern"] if "pattern" in others else "all"
+        gpu = not cpuonly
+        cpu = cpugpu or cpuonly
+        assert not (cpuonly and cpugpu), "cpuonly and cpugpu are mutually exclusive"
         func.meta = MethodMeta(
             method_name=func.__name__,
             signature=inspect.signature(func),
             module=inspect.getmodule(func).__name__.split("."),
             calc_max_slices=calc_max_slices,
             pattern=pattern,
+            gpu=gpu,
+            cpu=cpu,
             others=others,
             function=func,
         )
@@ -79,19 +146,42 @@ def method(calc_max_slices: MemoryFunction, **others):
     return _method
 
 
-def method_sino(calc_max_slices: MemorySinglePattern, **others):
-    
+def method_sino(
+    calc_max_slices: MemorySinglePattern = calc_max_slices_single_pattern_default,
+    cpuonly=False,
+    cpugpu=False,
+    **others,
+):
+    """
+    Decorator for exported tomography methods, annotating the method with
+    a function to calculate the memory requirements as well as other properties.
+
+    This is a convenience version for sinogram pattern - see method for details.
+    """
+
     def _calc_max_slices(_, otherdims, dtype, available_memory, **others):
         return calc_max_slices(otherdims, dtype, available_memory, **others)
-    
-    return method(calc_max_slices=_calc_max_slices, **others, pattern="sinogram")
+
+    return method(_calc_max_slices, cpuonly, cpugpu, **others, pattern="sinogram")
 
 
-def method_proj(calc_max_slices: MemorySinglePattern, **others):
+def method_proj(
+    calc_max_slices: MemorySinglePattern = calc_max_slices_single_pattern_default,
+    cpuonly=False,
+    cpugpu=False,
+    **others,
+):
+    """
+    Decorator for exported tomography methods, annotating the method with
+    a function to calculate the memory requirements as well as other properties.
+
+    This is a convenience version for projection pattern - see method for details.
+    """
+
     def _calc_max_slices(_, otherdims, dtype, available_memory, **others):
         return calc_max_slices(otherdims, dtype, available_memory, **others)
-    
-    return method(calc_max_slices=_calc_max_slices, **others, pattern="projection")
+
+    return method(_calc_max_slices, cpuonly, cpugpu, **others, pattern="projection")
 
 
 method_all = method

--- a/httomolib/misc/corr.py
+++ b/httomolib/misc/corr.py
@@ -24,11 +24,14 @@
 try:
     import cupy as cp
 except ImportError:
-    print('Cupy might be required for some methods in this module')    
+    print("Cupy might be required for some methods in this module")
 
+from typing import Tuple
 import numpy as np
+import nvtx
 
 from httomolib.cuda_kernels import load_cuda_module
+from httomolib.decorator import calc_max_slices_default, method_all
 
 __all__ = [
     "median_filter3d",
@@ -37,6 +40,8 @@ __all__ = [
 ]
 
 
+@method_all(calc_max_slices=calc_max_slices_default)
+@nvtx.annotate()
 def median_filter3d(
     data: cp.ndarray, kernel_size: int = 3, dif: float = 0.0
 ) -> cp.ndarray:
@@ -101,6 +106,7 @@ def median_filter3d(
     return out
 
 
+@method_all(calc_max_slices=calc_max_slices_default)
 def remove_outlier3d(
     data: cp.ndarray, kernel_size: int = 3, dif: float = 0.1
 ) -> cp.ndarray:
@@ -130,6 +136,7 @@ def remove_outlier3d(
     return median_filter3d(data=data, kernel_size=kernel_size, dif=dif)
 
 
+@method_all(cpuonly=True)
 def inpainting_filter3d(
     data: np.ndarray,
     mask: np.ndarray,

--- a/httomolib/misc/images.py
+++ b/httomolib/misc/images.py
@@ -27,12 +27,14 @@ import numpy as np
 from numpy import ndarray
 from PIL import Image
 from skimage import exposure
+from httomolib.decorator import method_all
 
 __all__ = [
     "save_to_images",
 ]
 
 
+@method_all(cpuonly=True)
 def save_to_images(
     data: ndarray,
     out_dir: str,

--- a/httomolib/misc/images.py
+++ b/httomolib/misc/images.py
@@ -22,6 +22,7 @@
 """ Module for loading/saving images """
 
 import os
+from typing import Optional
 
 import numpy as np
 from numpy import ndarray
@@ -45,7 +46,7 @@ def save_to_images(
     perc_range_min: float = 0.0,
     perc_range_max: float = 100.0,
     jpeg_quality: int = 95,
-    glob_stats: tuple = None,
+    glob_stats: Optional[tuple] = None,
     comm_rank: int = 0,
 ):
     """

--- a/httomolib/misc/morph.py
+++ b/httomolib/misc/morph.py
@@ -21,16 +21,34 @@
 # ---------------------------------------------------------------------------
 """Module for data type morphing functions"""
 
+import math
 import cupy as cp
 import numpy as np
 import nvtx
-from typing import Literal
+from typing import Literal, Tuple
+from httomolib.decorator import method_sino
 
 __all__ = [
     "sino_360_to_180",
 ]
 
 
+def _calc_max_slices_sino_360_to_180(
+    other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
+) -> int:
+    assert 'overlap' in kwargs, "Overlap not given"
+    overlap = int(math.round(kwargs['overlap']))
+    in_slice = np.prod(other_dims) * dtype.itemsize
+    out_slice = other_dims[0] * (other_dims[1] * 2 - overlap) / 2 * dtype.itemsize
+    # we have to leave this as 64bit to match tomopy?
+    weights = overlap * np.float64().nbytes
+
+    available_memory -= weights
+    return math.floor(available_memory / (in_slice + out_slice))
+
+
+
+@method_sino(_calc_max_slices_sino_360_to_180)
 @nvtx.annotate()
 def sino_360_to_180(
     data: cp.ndarray, overlap: int = 0, rotation: Literal["left", "right"] = "left"
@@ -56,7 +74,7 @@ def sino_360_to_180(
     """
     if data.ndim != 3:
         raise ValueError("only 3D data is supported")
-    
+
     dx, dy, dz = data.shape
 
     overlap = int(np.round(overlap))

--- a/httomolib/misc/morph.py
+++ b/httomolib/misc/morph.py
@@ -21,7 +21,6 @@
 # ---------------------------------------------------------------------------
 """Module for data type morphing functions"""
 
-import math
 import cupy as cp
 import numpy as np
 import nvtx
@@ -37,14 +36,14 @@ def _calc_max_slices_sino_360_to_180(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
 ) -> int:
     assert 'overlap' in kwargs, "Overlap not given"
-    overlap = int(math.round(kwargs['overlap']))
+    overlap = int(np.round(kwargs['overlap']))
     in_slice = np.prod(other_dims) * dtype.itemsize
     out_slice = other_dims[0] * (other_dims[1] * 2 - overlap) / 2 * dtype.itemsize
     # we have to leave this as 64bit to match tomopy?
     weights = overlap * np.float64().nbytes
 
     available_memory -= weights
-    return math.floor(available_memory / (in_slice + out_slice))
+    return int(np.floor(available_memory / (in_slice + out_slice)))
 
 
 

--- a/httomolib/misc/segm.py
+++ b/httomolib/misc/segm.py
@@ -24,12 +24,14 @@
 import numpy as np
 from numpy import ndarray
 from skimage import filters
+from httomolib.decorator import method_all
 
 __all__ = [
     "binary_thresholding",
 ]
 
 
+@method_all(cpuonly=True)
 def binary_thresholding(
     data: ndarray,
     val_intensity: float = 0.1,

--- a/httomolib/misc/segm.py
+++ b/httomolib/misc/segm.py
@@ -63,7 +63,7 @@ def binary_thresholding(
     """
 
     # initialising output mask
-    mask = np.uint8(np.zeros(np.shape(data)))
+    mask = np.zeros(np.shape(data), dtype=np.uint8)
 
     data_full_shape = np.shape(data)
     if data.ndim == 3:

--- a/httomolib/prep/alignment.py
+++ b/httomolib/prep/alignment.py
@@ -22,7 +22,7 @@
 """Modules for data correction"""
 
 import os
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import cupy as cp
 import nvtx
@@ -75,9 +75,9 @@ def distortion_correction_proj(
     data: cp.ndarray,
     metadata_path: str,
     preview: Dict[str, List[int]],
-    center_from_left: float = None,
-    center_from_top: float = None,
-    polynomial_coeffs: List[float] = None,
+    center_from_left: Optional[float] = None,
+    center_from_top: Optional[float] = None,
+    polynomial_coeffs: Optional[List[float]] = None,
     crop: int = 0,
 ):
     """Correct the radial distortion in the given stack of 2D images.

--- a/httomolib/prep/normalize.py
+++ b/httomolib/prep/normalize.py
@@ -47,7 +47,7 @@ def _normalize_max_slices(slice_dim: int,
     available_memory -= flats_mean_space + darks_mean_space
 
     # it also needs space for data input and output (we don't care about slice_dim)
-    in_slice_memory = np.prod(other_dims) * dtype().nbytes
+    in_slice_memory = np.prod(other_dims) * dtype.itemsize
     out_slice_memory = np.prod(other_dims) * float32().nbytes
     slice_memory = in_slice_memory + out_slice_memory
     max_slices = available_memory // slice_memory  # rounds down

--- a/httomolib/prep/normalize.py
+++ b/httomolib/prep/normalize.py
@@ -21,13 +21,41 @@
 # ---------------------------------------------------------------------------
 """Modules for raw projection data normalization"""
 
+from typing import Tuple
 import cupy as cp
+import numpy as np
 import nvtx
 from cupy import float32, log, mean, ndarray
+from httomolib import method_all
 
 __all__ = ["normalize"]
 
 
+def _normalize_max_slices(slice_dim: int, 
+                      other_dims: Tuple[int, int], 
+                      dtype: cp.dtype, 
+                      available_memory: int,
+                      **kwargs) -> int:
+    """Calculate the max chunk size it can fit in the available memory"""
+    
+    assert 'flats' in kwargs, "flats parameter is needed to calculate memory"
+    assert 'darks' in kwargs, "darks parameter is needed to calculate memory"
+
+    # normalize needs space to store the darks + flats and their means as a fixed cost
+    flats_mean_space = np.prod(kwargs['flats'].shape[1:]) * float32().nbytes
+    darks_mean_space = np.prod(kwargs['darks'].shape[1:]) * float32().nbytes
+    available_memory -= flats_mean_space + darks_mean_space
+
+    # it also needs space for data input and output (we don't care about slice_dim)
+    in_slice_memory = np.prod(other_dims) * dtype().nbytes
+    out_slice_memory = np.prod(other_dims) * float32().nbytes
+    slice_memory = in_slice_memory + out_slice_memory
+    max_slices = available_memory // slice_memory  # rounds down
+
+    return max_slices
+
+
+@method_all(calc_max_slices=_normalize_max_slices)
 @nvtx.annotate()
 def normalize(
     data: cp.ndarray,

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -505,7 +505,7 @@ def _calc_pad(
     """
     _, dy, dz = tomo.shape
     wavelength = _wavelength(energy)
-    py, pz, val = 0, 0, 0
+    py, pz, val = 0, 0, 0.0
     if pad:
         val = _calc_pad_val(tomo)
         py = _calc_pad_width(dy, pixel_size, wavelength, dist)

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -21,12 +21,15 @@
 # ---------------------------------------------------------------------------
 """Modules for phase retrieval and phase-contrast enhancement"""
 
+import math
+from typing import Tuple
 import cupy as cp
 import cupyx
 import numpy as np
 import nvtx
 
 from httomolib.cuda_kernels import load_cuda_module
+from httomolib.decorator import method_proj
 
 __all__ = [
     "fresnel_filter",
@@ -41,7 +44,29 @@ PI = 3.14159265359
 PLANCK_CONSTANT = 6.58211928e-19  # [keV*s]
 
 
+def _calc_max_slices_fresnel(
+    other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
+) -> int:
+    height1, width1 = other_dims
+    window_size = (height1 * width1) * np.float64().nbytes
+    pad_width = min(150, int(0.1 * width1))
+    padded_height = height1 + 2 * pad_width
+    padded_width = width1 * 2 * pad_width
+    in_slice_size = height1 * width1 * dtype.itemsize
+    # float64 here as res is internally computed in double
+    internal_slice_size = padded_height * padded_width * np.float64().nbytes
+    out_slice_size = padded_height * padded_width * np.float32().nbytes
+    slice_size = in_slice_size + out_slice_size + internal_slice_size
+    # the internal data is computed using a for loop, so the temporaries won't have
+    # a significant impact. But we add a safety margin for that
+    safety = in_slice_size * 4
+
+    available_memory -= window_size + safety
+    return available_memory // slice_size
+
+
 # CuPy implementation of Fresnel filter ported from Savu
+@method_proj(_calc_max_slices_fresnel)
 def fresnel_filter(
     mat: cp.ndarray, pattern: str, ratio: float, apply_log: bool = True
 ) -> cp.ndarray:
@@ -147,8 +172,29 @@ def _make_window(height, width, ratio, pattern):
     return win2d
 
 
+def _calc_max_slices_paganin_filter(
+    other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
+) -> int:
+    pad_x = kwargs["pad_x"]
+    pad_y = kwargs["pad_y"]
+    input_size = np.prod(other_dims) * dtype.itemsize
+    in_slice_size = (
+        (other_dims[0] + 2 * pad_y) * (other_dims[1] + 2 * pad_x) * dtype.itemsize
+    )
+    # FFT needs complex inputs, so copy to complex happens first
+    complex_slice = in_slice_size / dtype.itemsize * np.complex64().nbytes
+    fftplan_slice = complex_slice * 2.5
+    filter_size = complex_slice
+    res_slice = np.prod(other_dims) * np.float32().nbytes
+    temp_slice_size = in_slice_size * 2
+    slice_size = input_size + in_slice_size + temp_slice_size + complex_slice + fftplan_slice + res_slice
+    available_memory -= filter_size
+    return math.floor(available_memory / slice_size)
+
+
 ## %%%%%%%%%%%%%%%%%%%%%%% paganin_filter %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 #: CuPy implementation of Paganin filter from Savu
+@method_proj(_calc_max_slices_paganin_filter)
 @nvtx.annotate()
 def paganin_filter(
     data: cp.ndarray,
@@ -309,8 +355,36 @@ def paganin_filter(
     return res
 
 
+def _calc_max_slice_retrieve_phase(
+    other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
+) -> int:
+    dy, dz = other_dims
+    pixel_size = kwargs["pixel_size"]
+    energy = kwargs["energy"]
+    wavelength = _wavelength(energy)
+    dist = kwargs["dist"]
+    py = _calc_pad_width(dy, pixel_size, wavelength, dist)
+    pz = _calc_pad_width(dz, pixel_size, wavelength, dist)
+    # x 2 for ifftshift
+    grid_size = (dy + 2 * py) * (dz + 2 * pz) * np.float64().nbytes * 2
+    prj_size = (dy + 2 * py) * (dz + 2 * pz) * np.float32().nbytes * 2
+    prj_complex_size = prj_size * 2
+    fftplan_size = prj_complex_size
+    prj_ret_size = prj_complex_size
+    # the code goes through the projections line by line,
+    # which doesn't need any significant memory compared to the slices
+    # it also updates the inputs in-place
+
+    available_memory -= (
+        grid_size + prj_complex_size + prj_size + fftplan_size + prj_ret_size
+    )
+    slice_memory = np.prod(other_dims) * dtype.itemsize
+    return available_memory // slice_memory
+
+
 ## %%%%%%%%%%%%%%%%%%%%%%% retrieve_phase %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
 #: CuPy implementation of retrieve_phase from TomoPy
+@method_proj(_calc_max_slice_retrieve_phase)
 @nvtx.annotate()
 def retrieve_phase(
     tomo: cp.ndarray,

--- a/httomolib/recon/algorithm.py
+++ b/httomolib/recon/algorithm.py
@@ -60,8 +60,8 @@ def _calc_max_slices_reconstruct_tomobar(
 def reconstruct_tomobar(
     data: cp.ndarray,
     angles: np.ndarray,
-    center: float = None,
-    objsize: int = None,
+    center: Optional[float] = None,
+    objsize: Optional[int] = None,
     gpu_id: int = 0,
 ) -> cp.ndarray:
     """
@@ -182,7 +182,7 @@ def _calc_max_slices_reconstruct_tompy_astra(
 def reconstruct_tomopy_astra(
     data: np.ndarray,
     angles: np.ndarray,
-    center: float = None,
+    center: Optional[float] = None,
     algorithm: str = "FBP_CUDA",
     iterations: int = 1,
     proj_type: str = "cuda",

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -22,7 +22,7 @@
 """Modules for finding the axis of rotation"""
 
 import math
-from typing import Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 
 import cupy as cp
 import numpy as np
@@ -52,12 +52,12 @@ def _calc_max_slices_center_vo(
 @nvtx.annotate()
 def find_center_vo(
     data: cp.ndarray,
-    ind: int = None,
+    ind: Optional[int] = None,
     smin: int = -50,
     smax: int = 50,
-    srad: int = 6,
-    step: int = 0.25,
-    ratio: int = 0.5,
+    srad: float = 6.,
+    step: float = 0.25,
+    ratio: float = 0.5,
     drop: int = 20,
 ) -> float:
     """
@@ -122,7 +122,7 @@ def find_center_vo(
         init_cen = _search_coarse(_sino_cs, smin, smax, ratio, drop)
         fine_cen = _search_fine(_sino_fs, srad, step, init_cen, ratio, drop)
 
-    return np.float32(cp.asnumpy(fine_cen))
+    return cp.asnumpy(fine_cen, dtype=np.float32)
 
 
 @nvtx.annotate()
@@ -307,13 +307,13 @@ def _calc_max_slices_center_360(
 @nvtx.annotate()
 def find_center_360(
     data: cp.ndarray,
-    ind: int = None,
+    ind: Optional[int] = None,
     win_width: int = 10,
-    side: set = None,
+    side: Optional[Literal[0, 1]] = None,
     denoise: bool = True,
     norm: bool = False,
     use_overlap: bool = False,
-) -> Tuple[float, float, int, float]:
+) -> Tuple[float, float, Optional[Literal[0, 1]], float]:
     """
     Find the center-of-rotation (COR) in a 360-degree scan with offset COR use
     the method presented in Ref. [1] by Nghia Vo.
@@ -378,12 +378,12 @@ def find_center_360(
     else:
         cor = ncol - overlap / 2.0 - 1.0
 
-    return cp.float32(cor), cp.float32(overlap), side, cp.float32(overlap_position)
+    return float(cor), float(overlap), side, float(overlap_position)
 
 
 def _find_overlap(
     mat1, mat2, win_width, side=None, denoise=True, norm=False, use_overlap=False
-):
+) :
     """
     Find the overlap area and overlap side between two images (Ref. [1]) where
     the overlap side referring to the first image.

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -33,13 +33,22 @@ from cupy import ndarray
 from cupyx.scipy.ndimage import gaussian_filter, shift
 
 from httomolib.cuda_kernels import load_cuda_module
+from httomolib.decorator import method_sino
 
 __all__ = [
     "find_center_vo",
     "find_center_360",
 ]
 
+def _calc_max_slices_center_vo(
+    other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
+) -> int:
+    # the function works on one slice from the sinogram all the way through (picks a specific index)
+    # so memory is not restricted as long as a single slice can fit
+    return 1000000
 
+
+@method_sino(_calc_max_slices_center_vo)
 @nvtx.annotate()
 def find_center_vo(
     data: cp.ndarray,
@@ -285,7 +294,16 @@ def _downsample(sino, level, axis):
     return downsampled_data
 
 
+def _calc_max_slices_center_360(
+    other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
+) -> int:
+    # the function works on one slice from the sinogram all the way through (picks 0 or a specific index)
+    # so memory is not restricted as long as a single slice can fit
+    return 1000000
+
+
 # --- Center of rotation (COR) estimation method ---#
+@method_sino(_calc_max_slices_center_360)
 @nvtx.annotate()
 def find_center_360(
     data: cp.ndarray,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,26 @@
+import cupy as cp
+
+class MaxMemoryHook(cp.cuda.MemoryHook):
+    
+    def __init__(self, initial=0):
+        self.max_mem = initial
+        self.current = initial
+    
+    def malloc_postprocess(self, device_id: int, size: int, mem_size: int, mem_ptr: int, pmem_id: int):
+        self.current += mem_size
+        self.max_mem = max(self.max_mem, self.current)
+
+    def free_postprocess(self, device_id: int, mem_size: int, mem_ptr: int, pmem_id: int):
+        self.current -= mem_size
+
+    def alloc_preprocess(self, **kwargs):
+        pass
+
+    def alloc_postprocess(self, device_id: int, mem_size: int, mem_ptr: int):
+        pass
+    
+    def free_preprocess(self, **kwargs):
+        pass
+
+    def malloc_preprocess(self, **kwargs):
+        pass

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -1,0 +1,45 @@
+from httomolib import method_all, method_proj, method_sino, method_registry
+import inspect
+import numpy as np
+
+
+def test_adds_metdata():
+    @method_all(
+        calc_max_slices=lambda slice_dim, otherdims, dtype, available_memory, **kwargs: available_memory
+        // dtype().itemsize
+        // np.prod(otherdims)
+        // 2
+    )
+    def myfunc(a: int) -> int:
+        return a**2
+
+    assert myfunc.meta.method_name == "myfunc"
+    assert myfunc.meta.module == ["tests", "test_decorator"]
+    assert myfunc.meta.pattern == "all"
+    # last parameter '2' is mapped to the kwargs
+    assert myfunc.meta.calc_max_slices(0, (10, 10), np.int32, 40000, a=2) == 50
+    assert myfunc.__name__ == "myfunc"
+    assert inspect.getfullargspec(myfunc).args == ["a"]
+    assert myfunc(2) == 4
+
+    # also make sure it's in the method registry
+    assert method_registry["tests"]["test_decorator"]["myfunc"] == myfunc.meta
+    assert method_registry["tests"]["test_decorator"]["myfunc"](2) == 4
+
+
+def test_metadata_sino():
+    @method_sino(calc_max_slices=None)
+    def otherfunc(a: int) -> int:
+        pass
+
+    assert otherfunc.meta.pattern == "sinogram"
+
+
+def test_metadata_proj():
+    @method_proj(calc_max_slices=None)
+    def otherfunc(a: int) -> int:
+        pass
+
+    assert otherfunc.meta.pattern == "projection"
+
+

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -16,6 +16,8 @@ def test_adds_metdata():
     assert myfunc.meta.method_name == "myfunc"
     assert myfunc.meta.module == ["tests", "test_decorator"]
     assert myfunc.meta.pattern == "all"
+    assert myfunc.meta.cpu is False
+    assert myfunc.meta.gpu is True
     # last parameter '2' is mapped to the kwargs
     assert myfunc.meta.calc_max_slices(0, (10, 10), np.int32, 40000, a=2) == 50
     assert myfunc.__name__ == "myfunc"
@@ -43,3 +45,19 @@ def test_metadata_proj():
     assert otherfunc.meta.pattern == "projection"
 
 
+def test_metadata_cpu():
+    @method_all(cpuonly=True)
+    def otherfunc(a: int) -> int:
+        pass
+
+    assert otherfunc.meta.cpu is True
+    assert otherfunc.meta.gpu is False
+
+
+def test_metadata_cpu_and_gpu():
+    @method_all(cpugpu=True)
+    def otherfunc(a: int) -> int:
+        pass
+
+    assert otherfunc.meta.cpu is True
+    assert otherfunc.meta.gpu is True

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -29,9 +29,10 @@ def test_adds_metdata():
     assert method_registry["tests"]["test_decorator"]["myfunc"](2) == 4
 
 
+
 def test_metadata_sino():
     @method_sino(calc_max_slices=None)
-    def otherfunc(a: int) -> int:
+    def otherfunc(a: int):
         pass
 
     assert otherfunc.meta.pattern == "sinogram"
@@ -39,7 +40,7 @@ def test_metadata_sino():
 
 def test_metadata_proj():
     @method_proj(calc_max_slices=None)
-    def otherfunc(a: int) -> int:
+    def otherfunc(a: int):
         pass
 
     assert otherfunc.meta.pattern == "projection"
@@ -47,7 +48,7 @@ def test_metadata_proj():
 
 def test_metadata_cpu():
     @method_all(cpuonly=True)
-    def otherfunc(a: int) -> int:
+    def otherfunc(a: int):
         pass
 
     assert otherfunc.meta.cpu is True
@@ -56,7 +57,7 @@ def test_metadata_cpu():
 
 def test_metadata_cpu_and_gpu():
     @method_all(cpugpu=True)
-    def otherfunc(a: int) -> int:
+    def otherfunc(a: int):
         pass
 
     assert otherfunc.meta.cpu is True

--- a/tests/test_misc/test_morph.py
+++ b/tests/test_misc/test_morph.py
@@ -54,6 +54,11 @@ def test_sino_360_to_180_wrong_dims(ensure_clean_memory, shape):
         sino_360_to_180(cp.ones(shape, dtype=cp.float32))
 
 
+def test_sino_360_to_180_meta():
+    assert sino_360_to_180.meta.gpu is True
+    assert sino_360_to_180.meta.pattern == 'sinogram'
+
+
 @pytest.mark.parametrize("rotation", ["left", "right"])
 @pytest.mark.perf
 @cp.testing.gpu

--- a/tests/test_prep/test_alignment.py
+++ b/tests/test_prep/test_alignment.py
@@ -47,7 +47,7 @@ def test_correct_distortion(
 
     preview = {"starts": [0, 0], "stops": [im.shape[0], im.shape[1]], "steps": [1, 1]}
     corrected_data = implementation(im, distortion_coeffs_path, preview).get()
-
+    
     assert_allclose(np.mean(corrected_data), mean_value)
     assert np.max(corrected_data) == max_value
 

--- a/tests/test_prep/test_alignment.py
+++ b/tests/test_prep/test_alignment.py
@@ -7,8 +7,11 @@ from httomolib.prep.alignment import (
     distortion_correction_proj,
     distortion_correction_proj_discorpy,
 )
+from httomolib import method_registry
 from imageio.v2 import imread
 from numpy.testing import assert_allclose
+
+from tests import MaxMemoryHook
 
 
 @cp.testing.gpu
@@ -49,3 +52,37 @@ def test_correct_distortion(
     assert np.max(corrected_data) == max_value
 
     assert corrected_data.dtype == np.uint8
+
+
+@pytest.mark.parametrize("stack_size", [20, 50, 100])
+@pytest.mark.parametrize(
+    "implementation",
+    [distortion_correction_proj, distortion_correction_proj_discorpy],
+    ids=["cupy", "tomopy"],
+)
+def test_distortion_correction_meta(distortion_correction_path, stack_size, implementation):
+    distortion_coeffs_path = os.path.join(
+        distortion_correction_path, "distortion-coeffs.txt"
+    )
+
+    path = os.path.join(distortion_correction_path, "dot_pattern_03.tif")
+    im_host = np.asarray(imread(path))
+    im_host = np.expand_dims(im_host, axis=0)
+    # replicate into a stack of images
+    im_stack = cp.asarray(np.tile(im_host, (stack_size, 1, 1)))
+    hook = MaxMemoryHook(im_stack.size * im_stack.itemsize)
+    preview = {"starts": [0, 0], "stops": [im_stack.shape[1], im_stack.shape[2]], "steps": [1, 1]}
+    
+    with hook:
+        implementation(im_stack, distortion_coeffs_path, preview)
+    
+    # make sure estimator function is within range (80% min, 100% max)
+    max_mem = hook.max_mem
+    actual_slices = im_stack.shape[0]
+    estimated_slices = implementation.meta.calc_max_slices(
+        0, (im_stack.shape[1], im_stack.shape[2]), im_stack.dtype, max_mem, 
+        metadata_path=distortion_coeffs_path, preview=preview)
+    assert estimated_slices <= actual_slices
+    assert estimated_slices / actual_slices >= 0.8 
+    
+    assert implementation.__name__ in method_registry['httomolib']['prep']['alignment']

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -6,7 +6,10 @@ import pytest
 
 from numpy.testing import assert_allclose, assert_equal
 from httomolib.prep.normalize import normalize
+from httomolib import method_registry
 from cupy.cuda import nvtx
+
+from tests import MaxMemoryHook
 
 
 @cp.testing.gpu
@@ -25,7 +28,17 @@ def test_normalize_1D_raises(data, flats, darks, ensure_clean_memory):
 @cp.testing.gpu
 def test_normalize(data, flats, darks, ensure_clean_memory):
     # --- testing normalize  ---#
-    data_normalize = normalize(cp.copy(data), flats, darks, minus_log=True).get()
+    hook = MaxMemoryHook()
+    with hook:
+        data_normalize = normalize(cp.copy(data), flats, darks, minus_log=True).get()
+
+    # make sure estimator function is within range (80% min, 100% max)
+    max_mem = hook.max_mem
+    actual_slices = data.shape[0]
+    estimated_slices = normalize.meta.calc_max_slices(0, (data.shape[1], data.shape[2]), data.dtype, max_mem,
+                                                      flats=flats, darks=darks)
+    assert estimated_slices <= actual_slices
+    assert estimated_slices / actual_slices >= 0.8 
 
     assert data_normalize.dtype == np.float32
 
@@ -104,9 +117,11 @@ def test_normalize_memory_calc():
                 nonnegativity=False,
                 remove_nans=False)
     
+    assert 'normalize' in method_registry['httomolib']['prep']['normalize']
+
     # with 4-byte inputs and outputs, we can fit 198 slices between input / output
-    assert normalize.meta.calc_max_slices(0, (dy, dx), np.float32, available_memory, **args) == 99
+    assert normalize.meta.calc_max_slices(0, (dy, dx), np.float32(), available_memory, **args) == 99
 
     # with 2-byte inputs, 4-byte outputs, we can fit 132 (input takes only half the space)
-    assert normalize.meta.calc_max_slices(0, (dy, dx), np.uint16, available_memory, **args) == 132
+    assert normalize.meta.calc_max_slices(0, (dy, dx), np.uint16(), available_memory, **args) == 132
     

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -187,7 +187,7 @@ def test_retrieve_phase_1D_raises(ensure_clean_memory):
 
 @cp.testing.gpu
 def test_retrieve_phase(data):
-    hook = MaxMemoryHook(data.size * data.itemsize)
+    hook = MaxMemoryHook(data.nbytes)
     with hook:
         phase_data = retrieve_phase(data).get()
 

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -6,6 +6,8 @@ import pytest
 from cupy.cuda import nvtx
 from httomolib.prep.phase import fresnel_filter, paganin_filter, retrieve_phase
 from numpy.testing import assert_allclose
+from httomolib import method_registry
+from tests import MaxMemoryHook
 
 eps = 1e-6
 
@@ -23,6 +25,8 @@ def test_fresnel_filter_projection(data):
 
     #: make sure the output is float32
     assert filtered_data.dtype == np.float32
+    assert fresnel_filter.meta.pattern == 'projection'
+    assert 'fresnel_filter' in method_registry['httomolib']['prep']['phase']
 
 
 @cp.testing.gpu
@@ -51,7 +55,18 @@ def test_fresnel_filter_1D_raises(ensure_clean_memory):
 @cp.testing.gpu
 def test_paganin_filter(data):
     # --- testing the Paganin filter on tomo_standard ---#
-    filtered_data = paganin_filter(data).get()
+    
+    hook = MaxMemoryHook(data.size * data.itemsize)
+    with hook:
+        filtered_data = paganin_filter(data).get()
+    
+    # make sure estimator function is within range (80% min, 100% max)
+    max_mem = hook.max_mem
+    actual_slices = data.shape[0]
+    estimated_slices = paganin_filter.meta.calc_max_slices(
+        0, (data.shape[1], data.shape[2]), data.dtype, max_mem, pad_x=100, pad_y=100)
+    assert estimated_slices <= actual_slices
+    assert estimated_slices / actual_slices >= 0.8 
 
     assert filtered_data.ndim == 3
     assert_allclose(np.mean(filtered_data), -770.5339, rtol=eps)
@@ -59,6 +74,8 @@ def test_paganin_filter(data):
 
     #: make sure the output is float32
     assert filtered_data.dtype == np.float32
+    assert paganin_filter.meta.pattern == 'projection'
+    assert 'paganin_filter' in method_registry['httomolib']['prep']['phase']
 
 
 @cp.testing.gpu
@@ -170,7 +187,19 @@ def test_retrieve_phase_1D_raises(ensure_clean_memory):
 
 @cp.testing.gpu
 def test_retrieve_phase(data):
-    phase_data = retrieve_phase(data).get()
+    hook = MaxMemoryHook(data.size * data.itemsize)
+    with hook:
+        phase_data = retrieve_phase(data).get()
+
+    # make sure estimator function is within range (80% min, 100% max)
+    max_mem = hook.max_mem
+    actual_slices = data.shape[0]
+    estimated_slices = retrieve_phase.meta.calc_max_slices(
+        0, (data.shape[1], data.shape[2]), data.dtype, max_mem, 
+        pixel_size=1e-4, energy=20, dist=50)
+    assert estimated_slices <= actual_slices
+    assert estimated_slices / actual_slices >= 0.8 
+
     assert phase_data.shape == (180, 128, 160)
     assert np.sum(phase_data) == 2994544952
     assert_allclose(np.mean(phase_data), 812.3223068576389, rtol=1e-7)
@@ -180,6 +209,8 @@ def test_retrieve_phase(data):
 
     float32_phase_data = retrieve_phase(data.astype(cp.float32)).get()
     assert float32_phase_data.dtype == np.float32
+    assert retrieve_phase.meta.pattern == 'projection'
+    assert 'retrieve_phase' in method_registry['httomolib']['prep']['phase']
 
 
 @cp.testing.gpu

--- a/tests/test_recon/rotation_cpu_reference.py
+++ b/tests/test_recon/rotation_cpu_reference.py
@@ -1,16 +1,17 @@
+from typing import Literal, Optional
 import numpy as np
 import scipy.ndimage as ndi
 
 
 def find_center_360_numpy(
     data: np.ndarray,
-    ind: int = None,
+    ind: Optional[int] = None,
     win_width: int = 10,
-    side: set = None,
+    side: Optional[Literal[0, 1]] = None,
     denoise: bool = True,
     norm: bool = False,
     use_overlap: bool = False,
-) -> tuple[float, float, int, float]:
+) -> tuple[float, float, Optional[Literal[0, 1]], float]:
     """
     Numpy implementation - for reference in testing the cupy
     production version.
@@ -36,7 +37,7 @@ def find_center_360_numpy(
     else:
         cor = ncol - overlap / 2.0 - 1.0
 
-    return np.float32(cor), np.float32(overlap), side, np.float32(overlap_position)
+    return float(cor), float(overlap), side, float(overlap_position)
 
 
 def _find_overlap(

--- a/tests/test_recon/test_rotation.py
+++ b/tests/test_recon/test_rotation.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 from httomolib.prep.normalize import normalize
 from httomolib.recon.rotation import find_center_360, find_center_vo
+from httomolib import method_registry
 from numpy.testing import assert_allclose
 from .rotation_cpu_reference import find_center_360_numpy
 
@@ -21,6 +22,8 @@ def test_find_center_vo(data, flats, darks):
 
     #: Check that we only get a float32 output
     assert cor.dtype == np.float32
+    assert find_center_vo.meta.pattern == 'sinogram'
+    assert 'find_center_vo' in method_registry['httomolib']['recon']['rotation']
 
 
 @cp.testing.gpu
@@ -91,6 +94,8 @@ def test_find_center_360_data(data):
     #: Check that we only get a float32 output
     assert cor.dtype == np.float32
     assert overlap.dtype == np.float32
+    assert find_center_360.meta.pattern == 'sinogram'
+    assert 'find_center_360' in method_registry['httomolib']['recon']['rotation']
 
 
 @cp.testing.gpu


### PR DESCRIPTION
This adds memory estimation functions and decorators for the methods, including tests. This is documented in the `doc/decorators.rst` file as well as docstrings.

What is still missing:

- separate tests for decorators / memory estimation from the functional tests (example done in `test_alignment.py`)
- some methods are still missing these memory estimator tests. Adding them will reveal mistakes in the functions themselves
- possibly adapting the estimator functions to also return the output datatype, as that might change depending on inputs and parameters
- documentation cleanup