### PR TITLE
Chunked calculation + memory optimisation find_center_vo

### DIFF
--- a/httomolib/decorator.py
+++ b/httomolib/decorator.py
@@ -42,7 +42,7 @@ class MemoryFunction(Protocol):
         available_memory : int
             The available memory to fit the slices, in bytes
         kwargs : dict
-            Dictionary of the extra method paramters (apart from the data input)
+            Dictionary of the extra method parameters (apart from the data input)
 
         Returns
         -------

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -226,11 +226,13 @@ def _get_available_gpu_memory() -> int:
 def _calculate_chunks(nshifts: int, shift_size: int, available_memory: Optional[int] = None) -> List[int]:
     if available_memory is None:
         available_memory = _get_available_gpu_memory()
-
+    
+    available_memory -= shift_size
     freq_domain_size = shift_size  # it needs only half (RFFT), but complex64, so it's the same
     fft_plan_size = freq_domain_size
-    size_per_shift = fft_plan_size + freq_domain_size
+    size_per_shift = fft_plan_size + freq_domain_size + shift_size
     nshift_max = available_memory // size_per_shift
+    assert nshift_max > 0, "Not enough memory to process"
     num_chunks = int(np.ceil(nshifts / nshift_max))
     chunk_size = int(np.ceil(nshifts / num_chunks))
     chunks = [chunk_size] * (num_chunks - 1)

--- a/tests/test_misc/test_corr.py
+++ b/tests/test_misc/test_corr.py
@@ -98,10 +98,10 @@ def test_median_filter3d_memory_calc():
     args=dict(kernel_size=3, dif=1.5)
 
     assert 'median_filter3d' in method_registry['httomolib']['misc']['corr']
-    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.uint16, available_memory, **args) == 100
-    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.float32, available_memory, **args) == 50
-    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.uint16, available_memory, **args) == 100
-    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.float32, available_memory, **args) == 50
+    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.uint16(), available_memory, **args) == 100
+    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.float32(), available_memory, **args) == 50
+    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.uint16(), available_memory, **args) == 100
+    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.float32(), available_memory, **args) == 50
 
 
 @cp.testing.gpu

--- a/tests/test_recon/test_rotation.py
+++ b/tests/test_recon/test_rotation.py
@@ -55,22 +55,22 @@ def test_find_center_vo_calculate_chunks():
     # we need the split to fit into the available memory, and also make sure
     # that the last chunk is either the same or smaller than the previous ones
     # (so that we can re-use the same memory as for the previous chunks, incl. FFT plan)
-    # Note: With shift_size = 100 bytes, we need 200 bytes per shift
+    # Note: With shift_size = 100 bytes, we need 300 bytes per shift
     assert _calculate_chunks(10, 100, 1000000) == [10]
-    assert _calculate_chunks(10, 100, 10 * 200) == [10]
-    assert _calculate_chunks(10, 100, 5 * 200) == [5, 10]
-    assert _calculate_chunks(10, 100, 7 * 200) == [5, 10]
-    assert _calculate_chunks(10, 100, 9 * 200) == [5, 10]
-    assert _calculate_chunks(9, 100, 5 * 200) == [5, 9]
-    assert _calculate_chunks(10, 100, 4 * 200) == [4, 8, 10]
+    assert _calculate_chunks(10, 100, 10 * 300 + 100) == [10]
+    assert _calculate_chunks(10, 100, 5 * 300 + 100) == [5, 10]
+    assert _calculate_chunks(10, 100, 7 * 300 + 100) == [5, 10]
+    assert _calculate_chunks(10, 100, 9 * 300 + 100) == [5, 10]
+    assert _calculate_chunks(9, 100, 5 * 300 + 100) == [5, 9]
+    assert _calculate_chunks(10, 100, 4 * 300 + 100) == [4, 8, 10]
     # add a bit of randomness here, to check basic assumptions
     random.seed(123456)
     for _ in range(100):
-        available = random.randint(1*250, 100*200)  # memory to fit anywhere between 1 and 100 shifts
+        available = random.randint(1*300+100, 100*300 + 100)  # memory to fit anywhere between 1 and 100 shifts
         nshifts = random.randint(1, 1000)
         chunks = _calculate_chunks(nshifts, 100, available)
         assert len(chunks) > 0
-        assert len(chunks) == math.ceil(nshifts / (available // 200))
+        assert len(chunks) == math.ceil(nshifts / ((available - 100) // 300))
         assert chunks[-1] == nshifts
         if len(chunks) > 1:
             diffs = np.diff(chunks)


### PR DESCRIPTION
This adds chunked calculation for the `find_center_vo` method - in particular the `_calculate_metrics` function used internally. It does this by:

- first estimate the amount of memory required for each shift in the shifts array
- then determine how to chunk this array based on the available memory
- the chunking is done to make sure it's even as much as possible, and uses a smaller chunk for the last iteration only
- this is so that it can use the same FFT plan in each iteration, saving memory
- further, the `mean(abs(freq_data * mask))` has been combined into a `ReductionKernel`, which avoids another temporary array and hence reduces memory further
- Tests mock the available memory to check that the chunking is working as expected

We've also tested this code on a real GPU with limited memory and confirmed that it works fine.