### PR TITLE
Adjusts the calc_max_mem function to also return the output dtype

### DIFF
--- a/httomolib/decorator.py
+++ b/httomolib/decorator.py
@@ -26,7 +26,7 @@ class MemoryFunction(Protocol):
         dtype: np.dtype,
         available_memory: int,
         **kwargs,
-    ) -> int:
+    ) -> Tuple[int, np.dtype]:
         """
         Calculate the maximum number of slices that can fit in the given memory,
         for a method with the 'all' pattern.
@@ -46,8 +46,10 @@ class MemoryFunction(Protocol):
 
         Returns
         -------
-        int
-            The maximum number of slices that it can fit into the given available memory
+        Tuple[int, np.dtype]
+            Tuple consisting of:
+            - the maximum number of slices that it can fit into the given available memory
+            - the output dtype for the given input dtype
 
         """
         ...
@@ -66,7 +68,7 @@ class MemorySinglePattern(Protocol):
         dtype: np.dtype,
         available_memory: int,
         **kwargs,
-    ) -> int:
+    ) -> Tuple[int, np.dtype]:
         """
         Calculate the maximum number of slices that can fit in the given memory,
         for a method with the 'projection' or 'sinogram' pattern.
@@ -84,8 +86,10 @@ class MemorySinglePattern(Protocol):
 
         Returns
         -------
-        int
-            The maximum number of slices that it can fit into the given available memory
+        Tuple[int, np.dtype]
+            Tuple consisting of:
+            - the maximum number of slices that it can fit into the given available memory
+            - the output dtype for the given input dtype
 
         """
         ...
@@ -119,8 +123,7 @@ class MethodMeta:
     others : dict
         Dictionary of additional arbitrary meta information
     """
-
-    # TODO: output dtype somehow? assume output is same as input
+    
     method_name: str
     signature: inspect.Signature
     module: List[str]
@@ -145,19 +148,19 @@ def calc_max_slices_default(
     dtype: np.dtype,
     available_memory: int,
     **kwargs,
-) -> int:
+) -> Tuple[int, np.dtype]:
     """
     Default function for calculating maximum slices, which simply assumes
     space for input and output only is required, both with the same datatype,
     and no temporaries.
     """
 
-    return available_memory // (np.prod(other_dims) * dtype.itemsize * 2)
+    return available_memory // (np.prod(other_dims) * dtype.itemsize * 2), dtype
 
 
 def calc_max_slices_single_pattern_default(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     """
     Default function for calculating maximum slices, which simply assumes
     space for input and output only is required, both with the same datatype,

--- a/httomolib/misc/morph.py
+++ b/httomolib/misc/morph.py
@@ -34,7 +34,7 @@ __all__ = [
 
 def _calc_max_slices_sino_360_to_180(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     assert 'overlap' in kwargs, "Overlap not given"
     overlap = int(np.round(kwargs['overlap']))
     in_slice = np.prod(other_dims) * dtype.itemsize
@@ -43,7 +43,7 @@ def _calc_max_slices_sino_360_to_180(
     weights = overlap * np.float64().nbytes
 
     available_memory -= weights
-    return int(np.floor(available_memory / (in_slice + out_slice)))
+    return int(np.floor(available_memory / (in_slice + out_slice))), dtype
 
 
 

--- a/httomolib/prep/alignment.py
+++ b/httomolib/prep/alignment.py
@@ -63,7 +63,7 @@ def _calc_max_slices_distortion_correction_proj(
         + indices_size * 3  # The x 3 here is for additional safety margin 
     )                       # to allow for memory for temporaries
 
-    return available_memory // slice_size
+    return available_memory // slice_size, dtype
 
 
 ## %%%%%%%%%%%%%%%%%%%%%%%%%distortion_correction_proj%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##

--- a/httomolib/prep/normalize.py
+++ b/httomolib/prep/normalize.py
@@ -33,7 +33,7 @@ __all__ = ["normalize"]
 
 def _normalize_max_slices(
     other_dims: Tuple[int, int], dtype: cp.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     """Calculate the max chunk size it can fit in the available memory"""
 
     # normalize needs space to store the darks + flats and their means as a fixed cost
@@ -48,7 +48,7 @@ def _normalize_max_slices(
     slice_memory = in_slice_memory + out_slice_memory
     max_slices = available_memory // slice_memory  # rounds down
 
-    return max_slices
+    return max_slices, float32()
 
 
 @method_proj(calc_max_slices=_normalize_max_slices)

--- a/httomolib/prep/phase.py
+++ b/httomolib/prep/phase.py
@@ -46,7 +46,7 @@ PLANCK_CONSTANT = 6.58211928e-19  # [keV*s]
 
 def _calc_max_slices_fresnel(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     height1, width1 = other_dims
     window_size = (height1 * width1) * np.float64().nbytes
     pad_width = min(150, int(0.1 * width1))
@@ -62,7 +62,7 @@ def _calc_max_slices_fresnel(
     safety = in_slice_size * 4
 
     available_memory -= window_size + safety
-    return available_memory // slice_size
+    return available_memory // slice_size, np.float32()
 
 
 # CuPy implementation of Fresnel filter ported from Savu
@@ -174,7 +174,7 @@ def _make_window(height, width, ratio, pattern):
 
 def _calc_max_slices_paganin_filter(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     pad_x = kwargs["pad_x"]
     pad_y = kwargs["pad_y"]
     input_size = np.prod(other_dims) * dtype.itemsize
@@ -188,7 +188,7 @@ def _calc_max_slices_paganin_filter(
     res_slice = np.prod(other_dims) * np.float32().nbytes    
     slice_size = input_size + in_slice_size + complex_slice + fftplan_slice + res_slice
     available_memory -= filter_size
-    return available_memory // slice_size
+    return available_memory // slice_size, np.float32()
 
 
 ## %%%%%%%%%%%%%%%%%%%%%%% paganin_filter %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
@@ -357,7 +357,7 @@ def paganin_filter(
 
 def _calc_max_slice_retrieve_phase(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     dy, dz = other_dims
     pixel_size = kwargs["pixel_size"]
     energy = kwargs["energy"]
@@ -379,7 +379,7 @@ def _calc_max_slice_retrieve_phase(
         grid_size + prj_complex_size + prj_size + fftplan_size + prj_ret_size
     )
     slice_memory = np.prod(other_dims) * dtype.itemsize
-    return available_memory // slice_memory
+    return available_memory // slice_memory, dtype
 
 
 ## %%%%%%%%%%%%%%%%%%%%%%% retrieve_phase %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##

--- a/httomolib/prep/stripe.py
+++ b/httomolib/prep/stripe.py
@@ -38,7 +38,7 @@ __all__ = [
 
 def _calc_max_slices_stripe_based_sorting(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     # the algorithm calls _rsort for each slice independenty, and it needs 
     # several temporaries in the order of the input slice.
     # Those temporaries are independent of the number of slices and represent a fixed 
@@ -46,7 +46,7 @@ def _calc_max_slices_stripe_based_sorting(
     slice_mem = np.prod(other_dims) * dtype.itemsize * 1.25
     temp_mem = slice_mem * 8
     available_memory -= temp_mem
-    return available_memory // slice_mem
+    return available_memory // slice_mem, dtype
 
 
 @method_sino(_calc_max_slices_stripe_based_sorting, cpugpu=True)
@@ -128,7 +128,7 @@ def _rs_sort(sinogram, size, dim):
 
 def _calc_max_slices_remove_stripe_ti(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     # This is admittedly a rough estimation, but it should be about right
     gamma_mem = other_dims[1] * np.float64().itemsize
     
@@ -138,7 +138,7 @@ def _calc_max_slices_remove_stripe_ti(
     extra_temp_mem = slice_mean_mem * 8
 
     available_memory -= gamma_mem
-    return available_memory // (in_slice_mem + slice_mean_mem + slice_fft_plan_mem + extra_temp_mem)
+    return available_memory // (in_slice_mem + slice_mean_mem + slice_fft_plan_mem + extra_temp_mem), dtype
 
 
 @method_sino(_calc_max_slices_remove_stripe_ti, cpugpu=True)

--- a/httomolib/recon/algorithm.py
+++ b/httomolib/recon/algorithm.py
@@ -39,7 +39,7 @@ __all__ = [
 
 def _calc_max_slices_reconstruct_tomobar(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     # we first run filtersync, and calc the memory for that - how com it's 
     DetectorsLengthH = other_dims[1]
     in_slice_size = np.prod(other_dims) * dtype.itemsize
@@ -51,7 +51,7 @@ def _calc_max_slices_reconstruct_tomobar(
     astra_size = in_slice_size * 2
 
     available_memory -= filter_size
-    return available_memory // (in_slice_size + freq_slice + fftplan_size + swapaxis_size + astra_size)
+    return available_memory // (in_slice_size + freq_slice + fftplan_size + swapaxis_size + astra_size), np.float32()
 
 
 ## %%%%%%%%%%%%%%%%%%%%%%% ToMoBAR reconstruction %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%  ##
@@ -165,15 +165,15 @@ def _filtersinc3D_cupy(projection3D):
 
 def _calc_max_slices_reconstruct_tompy_astra(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     algorithm = kwargs['algorithm']
     # we don't know how Astra uses the memory - we can only guess
     if algorithm  == 'FBP_CUDA':
         slice_mem = np.prod(other_dims) * dtype.itemsize * 4
-        return available_memory // slice_mem
+        return available_memory // slice_mem, dtype
 
     # no GPU used, we're not really limiting this
-    return available_memory // np.prod(other_dims) // dtype.itemsize
+    return available_memory // np.prod(other_dims) // dtype.itemsize, dtype
 
 
 ## %%%%%%%%%%%%%%%%%%%%%%% Tomopy/ASTRA reconstruction %%%%%%%%%%%%%%%%%%%%%%%%%%  ##

--- a/httomolib/recon/rotation.py
+++ b/httomolib/recon/rotation.py
@@ -43,10 +43,10 @@ __all__ = [
 
 def _calc_max_slices_center_vo(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     # the function works on one slice from the sinogram all the way through (picks a specific index)
     # so memory is not restricted as long as a single slice can fit
-    return 1000000
+    return 1000000, dtype
 
 
 @method_sino(_calc_max_slices_center_vo)
@@ -349,10 +349,10 @@ def _downsample(sino, level, axis):
 
 def _calc_max_slices_center_360(
     other_dims: Tuple[int, int], dtype: np.dtype, available_memory: int, **kwargs
-) -> int:
+) -> Tuple[int, np.dtype]:
     # the function works on one slice from the sinogram all the way through (picks 0 or a specific index)
     # so memory is not restricted as long as a single slice can fit
-    return 1000000
+    return 1000000, dtype
 
 
 # --- Center of rotation (COR) estimation method ---#

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -5,10 +5,10 @@ import numpy as np
 
 def test_adds_metdata():
     @method_all(
-        calc_max_slices=lambda slice_dim, otherdims, dtype, available_memory, **kwargs: available_memory
+        calc_max_slices=lambda slice_dim, otherdims, dtype, available_memory, **kwargs: (available_memory
         // dtype().itemsize
         // np.prod(otherdims)
-        // 2
+        // 2, dtype)
     )
     def myfunc(a: int) -> int:
         return a**2
@@ -19,7 +19,7 @@ def test_adds_metdata():
     assert myfunc.meta.cpu is False
     assert myfunc.meta.gpu is True
     # last parameter '2' is mapped to the kwargs
-    assert myfunc.meta.calc_max_slices(0, (10, 10), np.int32, 40000, a=2) == 50
+    assert myfunc.meta.calc_max_slices(0, (10, 10), np.int32(), 40000, a=2) == (50, np.int32())
     assert myfunc.__name__ == "myfunc"
     assert inspect.getfullargspec(myfunc).args == ["a"]
     assert myfunc(2) == 4

--- a/tests/test_misc/test_corr.py
+++ b/tests/test_misc/test_corr.py
@@ -98,10 +98,10 @@ def test_median_filter3d_memory_calc():
     args=dict(kernel_size=3, dif=1.5)
 
     assert 'median_filter3d' in method_registry['httomolib']['misc']['corr']
-    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.uint16(), available_memory, **args) == 100
-    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.float32(), available_memory, **args) == 50
-    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.uint16(), available_memory, **args) == 100
-    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.float32(), available_memory, **args) == 50
+    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.uint16(), available_memory, **args) == (100, np.uint16())
+    assert median_filter3d.meta.calc_max_slices(0, (dy, dx), np.float32(), available_memory, **args) == (50, np.float32())
+    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.uint16(), available_memory, **args) == (100, np.uint16())
+    assert median_filter3d.meta.calc_max_slices(1, (dy, dx), np.float32(), available_memory, **args) == (50, np.float32())
 
 
 @cp.testing.gpu

--- a/tests/test_prep/test_alignment.py
+++ b/tests/test_prep/test_alignment.py
@@ -79,7 +79,7 @@ def test_distortion_correction_meta(distortion_correction_path, stack_size, impl
     # make sure estimator function is within range (80% min, 100% max)
     max_mem = hook.max_mem
     actual_slices = im_stack.shape[0]
-    estimated_slices = implementation.meta.calc_max_slices(
+    estimated_slices, _ = implementation.meta.calc_max_slices(
         0, (im_stack.shape[1], im_stack.shape[2]), im_stack.dtype, max_mem, 
         metadata_path=distortion_coeffs_path, preview=preview)
     assert estimated_slices <= actual_slices

--- a/tests/test_prep/test_normalize.py
+++ b/tests/test_prep/test_normalize.py
@@ -47,7 +47,7 @@ def test_normalize_meta(data, flats, darks, ensure_clean_memory):
     # make sure estimator function is within range (80% min, 100% max)
     max_mem = hook.max_mem
     actual_slices = data.shape[0]
-    estimated_slices = normalize.meta.calc_max_slices(0, (data.shape[1], data.shape[2]), data.dtype, max_mem,
+    estimated_slices, _ = normalize.meta.calc_max_slices(0, (data.shape[1], data.shape[2]), data.dtype, max_mem,
                                                       flats=flats, darks=darks)
     assert estimated_slices <= actual_slices
     assert estimated_slices / actual_slices >= 0.8

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -83,7 +83,7 @@ def test_paganin_filter_meta(pad, slices, dtype):
     # make sure estimator function is within range (80% min, 100% max)
     max_mem = hook.max_mem
     actual_slices = data.shape[0]
-    estimated_slices = paganin_filter.meta.calc_max_slices(
+    estimated_slices, _ = paganin_filter.meta.calc_max_slices(
         0, (data.shape[1], data.shape[2]), data.dtype, max_mem, **kwargs)
     assert estimated_slices <= actual_slices
     assert estimated_slices / actual_slices >= 0.8    
@@ -222,7 +222,7 @@ def test_retrieve_phase_meta(data):
     # make sure estimator function is within range (80% min, 100% max)
     max_mem = hook.max_mem
     actual_slices = data.shape[0]
-    estimated_slices = retrieve_phase.meta.calc_max_slices(
+    estimated_slices, _ = retrieve_phase.meta.calc_max_slices(
         0, (data.shape[1], data.shape[2]), data.dtype, max_mem, 
         pixel_size=1e-4, energy=20, dist=50)
     assert estimated_slices <= actual_slices

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -44,7 +44,7 @@ def test_remove_stripe_ti_on_data_meta(data, flats, darks):
     # make sure estimator function is within range (80% min, 100% max)
     max_mem = hook.max_mem
     actual_slices = data.shape[1]
-    estimated_slices = remove_stripe_ti.meta.calc_max_slices(1, (data.shape[0], data.shape[2]), data.dtype, max_mem)
+    estimated_slices, _ = remove_stripe_ti.meta.calc_max_slices(1, (data.shape[0], data.shape[2]), data.dtype, max_mem)
     assert estimated_slices <= actual_slices
     assert estimated_slices / actual_slices >= 0.8 
 
@@ -100,7 +100,7 @@ def test_stripe_removal_sorting_cupy_meta(data, flats, darks):
     # make sure estimator function is within range (80% min, 100% max)
     max_mem = hook.max_mem
     actual_slices = data.shape[1]
-    estimated_slices = remove_stripe_based_sorting.meta.calc_max_slices(1, (data.shape[0], data.shape[2]), data.dtype, max_mem)
+    estimated_slices, _ = remove_stripe_based_sorting.meta.calc_max_slices(1, (data.shape[0], data.shape[2]), data.dtype, max_mem)
     assert estimated_slices <= actual_slices
     assert estimated_slices / actual_slices >= 0.8 
     

--- a/tests/test_recon/test_algorithm.py
+++ b/tests/test_recon/test_algorithm.py
@@ -60,7 +60,7 @@ def test_reconstruct_tomobar_device_3(data, flats, darks, ensure_clean_memory):
     # make sure estimator function is within range (80% min, 100% max)
     max_mem = hook.max_mem
     actual_slices = data.shape[1]
-    estimated_slices = reconstruct_tomobar.meta.calc_max_slices(1, (data.shape[0], data.shape[2]), data.dtype, max_mem)
+    estimated_slices, _ = reconstruct_tomobar.meta.calc_max_slices(1, (data.shape[0], data.shape[2]), data.dtype, max_mem)
     assert estimated_slices <= actual_slices
     assert estimated_slices / actual_slices >= 0.8 
     


### PR DESCRIPTION
Some methods return different data types in their outputs than what they were given. This information is important for the memory calculations of the methods that follow. Therefore this PR adjusts the memory calculation function to return a `Tuple[int, np.dtype]` instead of just an `int`. 