### PR TITLE
set the correct dimension labels

### DIFF
--- a/httomolibgpu/recon/algorithm.py
+++ b/httomolibgpu/recon/algorithm.py
@@ -146,6 +146,7 @@ def FBP_CIL(
             rotation_axis_position=(center - panel_centre, 0, 0)
         )
         ag.set_panel(num_pixels=(det_x, det_y), pixel_size=(1.0, 1.0))
+        ag.dimension_labels = [AcquisitionGeometry.VERTICAL, AcquisitionGeometry.ANGLE, AcquisitionGeometry.HORIZONTAL]
 
         if objsize is not None:
             ig = ImageGeometry(
@@ -165,6 +166,7 @@ def FBP_CIL(
             rotation_axis_position=(center - panel_centre, 0)
         )
         ag.set_panel(num_pixels=det_x, pixel_size=1.0)
+        ag.dimension_labels = [AcquisitionGeometry.ANGLE, AcquisitionGeometry.HORIZONTAL]
 
         if objsize is not None:
             ig = ImageGeometry(

--- a/httomolibgpu/recon/algorithm.py
+++ b/httomolibgpu/recon/algorithm.py
@@ -146,7 +146,11 @@ def FBP_CIL(
             rotation_axis_position=(center - panel_centre, 0, 0)
         )
         ag.set_panel(num_pixels=(det_x, det_y), pixel_size=(1.0, 1.0))
-        ag.dimension_labels = [AcquisitionGeometry.VERTICAL, AcquisitionGeometry.ANGLE, AcquisitionGeometry.HORIZONTAL]
+        ag.dimension_labels = [
+            AcquisitionGeometry.VERTICAL,
+            AcquisitionGeometry.ANGLE,
+            AcquisitionGeometry.HORIZONTAL,
+        ]
 
         if objsize is not None:
             ig = ImageGeometry(
@@ -166,7 +170,10 @@ def FBP_CIL(
             rotation_axis_position=(center - panel_centre, 0)
         )
         ag.set_panel(num_pixels=det_x, pixel_size=1.0)
-        ag.dimension_labels = [AcquisitionGeometry.ANGLE, AcquisitionGeometry.HORIZONTAL]
+        ag.dimension_labels = [
+            AcquisitionGeometry.ANGLE,
+            AcquisitionGeometry.HORIZONTAL,
+        ]
 
         if objsize is not None:
             ig = ImageGeometry(
@@ -176,7 +183,7 @@ def FBP_CIL(
                 voxel_size_y=1.0,
             )
 
-    ag.set_angles(angles, angle_unit="radian")
+    ag.set_angles(-angles, angle_unit="radian")
 
     if objsize is None:
         ig = ag.get_ImageGeometry()
@@ -190,15 +197,18 @@ def FBP_CIL(
     # create the FBP recon with backend ASTRA
     fbp = FBP(input=adata, image_geometry=ig, filter=filter, backend="astra")
 
-    if num_slices is not None:
-        fbp.set_split_processing(slices_per_chunk=num_slices)
+    # if num_slices is not None:
+    #    fbp.set_split_processing(slices_per_chunk=num_slices)
 
-    if gpu_id is not None:
-        import astra
+    # if gpu_id is not None:
+    #     import astra
 
-        astra.set_gpu_index(gpu_id)
+    #     astra.set_gpu_index(gpu_id)
 
     reconstruction = fbp.run(verbose=0)
+    reconstruction.reorder(
+        [ImageGeometry.HORIZONTAL_X, ImageGeometry.VERTICAL, ImageGeometry.HORIZONTAL_Y]
+    )
 
     # return numpy array
     return reconstruction.as_array()

--- a/tests/test_recon/test_algorithm.py
+++ b/tests/test_recon/test_algorithm.py
@@ -98,10 +98,9 @@ def test_reconstruct_FBP_CIL(data, flats, darks, ensure_clean_memory):
     center = 79.5
     recon_data = FBP_CIL(normalized_data, angles, center, objsize=objrecon_size)
 
-    # assert_allclose(np.mean(recon_data), 0.000798, rtol=1e-07, atol=1e-6)
-    # assert_allclose(np.mean(recon_data, axis=(0, 2)).sum(), 0.102106, rtol=1e-05)
-    # assert_allclose(np.std(recon_data), 0.006293, rtol=1e-07, atol=1e-6)
-    # assert_allclose(np.median(recon_data), -0.000555, rtol=1e-07, atol=1e-6)
+    assert_allclose(np.mean(recon_data), 0.0017743068, atol=1e-6)
+    assert_allclose(np.max(recon_data), 0.03704812, atol=1e-6)
+    assert_allclose(np.min(recon_data), -0.013717581, atol=1e-6)
     assert recon_data.dtype == np.float32
     assert recon_data.shape == (160, 128, 160)
 


### PR DESCRIPTION
Default `AcquisitionGeometry` expects [different dimension labels](https://github.com/TomographicImaging/CIL/blob/f9102f996ba9bfe89940c1ef1b67dfe9cca5de3e/Wrappers/Python/cil/framework/framework.py#L4234) than what is passed, leading to a

```
ValueError: Shape mismatch got (128, 180, 160) expected (180, 128, 160)
```