### PR TITLE
Adds a rescale_to_int method for mapping float data to integer range

### DIFF
--- a/httomolibgpu/misc/rescale.py
+++ b/httomolibgpu/misc/rescale.py
@@ -1,0 +1,85 @@
+import cupy as cp
+import numpy as np
+from typing import Literal, Optional, Tuple, Union
+
+__all__ = [
+    "rescale_to_int",
+]
+
+
+rescale_kernel = cp.ElementwiseKernel(
+    'T x, raw T input_min, raw T input_max, raw T factor',
+    'O out',
+    '''
+      T x_clean = isnan(x) || isinf(x) ? T(0) : x;
+      T x_clipped = x_clean < input_min ? input_min : (x_clean > input_max ? input_max : x_clean);
+      T x_rebased = x_clipped - input_min;
+      out = O(x_rebased * factor);
+    ''',
+    'rescale_to_int'
+)
+
+def rescale_to_int(data: cp.ndarray, 
+            perc_range_min: float = 0.0,
+            perc_range_max: float = 100.0,
+            bits: Literal[8, 16, 32] = 8, 
+            glob_stats: Optional[Tuple[float, float, float, int]] = None):
+    """
+        Rescales the data and converts it fit into the range of an unsigned integer type
+        with the given number of bits.
+        
+        Parameters
+        ----------
+        data : cp.ndarray
+            Required input data array, on GPU
+        perc_range_min: float, optional
+            The lower cutoff point in the input data, in percent of the data range (defaults to 0).
+            The lower bound is computed as min + perc_range_min/100*(max-min)
+        perc_range_max: float, optional
+            The upper cutoff point in the input data, in percent of the data range (defaults to 100).
+            The upper bound is computed as min + perc_range_max/100*(max-min)
+        bits: Literal[8, 16, 32], optional
+            The number of bits in the output integer range (defaults to 8). 
+            Allowed values are:
+            - 8 -> uint8
+            - 16 -> uint16
+            - 32 -> uint32
+        glob_stats: tuple, optional
+            Global statistics of the full dataset (beyond the data passed into this call).
+            It's a tuple with (min, max, sum, num_items). If not given, the min/max is 
+            computed from the given data.
+            
+        Returns
+        -------
+        cp.ndarray
+            The original data, clipped to the range specified with the perc_range_min and 
+            perc_range_max, and scaled to the full range of the output integer type
+    """
+    
+    if bits == 8:
+        output_dtype: Union[type[np.uint8], type[np.uint16], type[np.uint32]] = np.uint8
+    elif bits == 16:
+        output_dtype = np.uint16
+    else:
+        output_dtype = np.uint32
+    
+    # get the min and max integer values of the output type
+    output_min = np.iinfo(output_dtype).min
+    output_max = np.iinfo(output_dtype).max
+    
+    if not isinstance(glob_stats, tuple):
+        min_value = float(cp.min(data))
+        max_value = float(cp.max(data))
+    else:
+        min_value = glob_stats[0]
+        max_value = glob_stats[1]
+    
+    range_intensity = max_value - min_value
+    input_min = (perc_range_min * (range_intensity) / 100) + min_value
+    input_max = (perc_range_max * (range_intensity) / 100) + min_value
+    
+    factor = (output_max - output_min) / (input_max - input_min)
+    
+    res = cp.empty(data.shape, dtype=output_dtype)
+    rescale_kernel(data, input_min, input_max, factor, res)
+    return res

--- a/httomolibgpu/misc/rescale.py
+++ b/httomolibgpu/misc/rescale.py
@@ -1,6 +1,7 @@
 import cupy as cp
 import numpy as np
 from typing import Literal, Optional, Tuple, Union
+import nvtx
 
 __all__ = [
     "rescale_to_int",
@@ -19,6 +20,7 @@ rescale_kernel = cp.ElementwiseKernel(
     'rescale_to_int'
 )
 
+@nvtx.annotate()
 def rescale_to_int(data: cp.ndarray, 
             perc_range_min: float = 0.0,
             perc_range_max: float = 100.0,

--- a/tests/test_misc/test_rescale.py
+++ b/tests/test_misc/test_rescale.py
@@ -1,0 +1,131 @@
+import time
+from typing import Literal
+import numpy as np
+import cupy as cp
+import pytest
+from cupy.cuda import nvtx
+
+from httomolibgpu.misc.rescale import rescale_to_int
+
+
+def test_rescale_no_change():
+    data = np.random.randint(0, 255, size=(50, 50), dtype=np.uint8).astype(np.float32)
+    data_dev = cp.asarray(data)
+    res_dev = rescale_to_int(
+        data_dev, bits=8, glob_stats=(0.0, 255.0, 100.0, data.size)
+    )
+
+    res = cp.asnumpy(res_dev).astype(np.float32)
+
+    assert res_dev.dtype == np.uint8
+    np.testing.assert_array_equal(res, data)
+
+
+@pytest.mark.parametrize("bits", [8, 16, 32])
+def test_rescale_no_change_no_stats(bits: Literal[8, 16, 32]):
+    data = np.ones((30, 50), dtype=np.float32)
+    data[0, 0] = 0.0
+    data[13, 1] = (2**bits) - 1
+    data_dev = cp.asarray(data)
+    res_dev = rescale_to_int(data_dev, bits=bits)
+
+    res = cp.asnumpy(res_dev).astype(np.float32)
+
+    assert res_dev.dtype.itemsize == bits // 8
+    np.testing.assert_array_equal(res, data)
+
+
+def test_rescale_double():
+    data = np.ones((30, 50), dtype=np.float32)
+
+    data_dev = cp.asarray(data)
+    res_dev = rescale_to_int(data_dev, bits=8, glob_stats=(0, 2, 100, data.size))
+
+    res = cp.asnumpy(res_dev).astype(np.float32)
+
+    np.testing.assert_array_almost_equal(res, 127.0)
+
+
+def test_rescale_handles_nan_inf():
+    data = np.ones((30, 50), dtype=np.float32)
+    data[0, 0] = float("nan")
+    data[0, 1] = float("inf")
+    data[0, 2] = float("-inf")
+
+    data_dev = cp.asarray(data)
+    res_dev = rescale_to_int(data_dev, bits=8, glob_stats=(0, 2, 100, data.size))
+
+    res = cp.asnumpy(res_dev).astype(np.float32)
+
+    np.testing.assert_array_equal(res[0, 0:3], 0.0)
+
+
+def test_rescale_double_offset():
+    data = np.ones((30, 50), dtype=np.float32) + 10
+
+    data_dev = cp.asarray(data)
+    res_dev = rescale_to_int(data_dev, bits=8, glob_stats=(10, 12, 100, data.size))
+
+    res = cp.asnumpy(res_dev).astype(np.float32)
+
+    np.testing.assert_array_almost_equal(res, 127.0)
+
+
+@pytest.mark.parametrize("bits", [8, 16])
+def test_rescale_double_offset_min_percentage(bits: Literal[8, 16, 32]):
+    data = np.ones((30, 50), dtype=np.float32) + 15
+    data[0, 0] = 10
+    data[0, 1] = 20
+
+    data_dev = cp.asarray(data)
+    res_dev = rescale_to_int(
+        data_dev,
+        bits=bits,
+        glob_stats=(10, 20, 100, data.size),
+        perc_range_min=10.0,
+        perc_range_max=90.0,
+    )
+
+    res = cp.asnumpy(res_dev).astype(np.float32)
+
+    max = (2**bits) - 1
+    num = int(5 / 8 * max)
+    # note: with 32bit, the float type actually overflows and the result is not full precision
+    np.testing.assert_array_almost_equal(res[1:, :], num)
+    assert res[0, 0] == 0.0
+    assert res[0, 1] == max
+
+
+@pytest.mark.perf
+def test_rescale_performance():
+    data = cp.random.random((1801, 400, 2560), dtype=np.float32) * 500 + 20
+    in_min = float(cp.min(data))
+    in_max = float(cp.max(data))
+
+    # do a cold run first
+    rescale_to_int(
+        data,
+        bits=8,
+        glob_stats=(in_min, in_max, 100.0, data.size),
+        perc_range_max=95.0,
+        perc_range_min=5.0,
+    )
+
+    dev = cp.cuda.Device()
+    dev.synchronize()
+
+    start = time.perf_counter_ns()
+    nvtx.RangePush("Core")
+    for _ in range(20):
+        rescale_to_int(
+            data,
+            bits=8,
+            glob_stats=(in_min, in_max, 100.0, data.size),
+            perc_range_max=95.0,
+            perc_range_min=5.0,
+        )
+    nvtx.RangePop()
+    dev.synchronize()
+    duration_ms = float(time.perf_counter_ns() - start) * 1e-6 / 20
+
+    assert "performance in ms" == duration_ms


### PR DESCRIPTION
This method is implemented and optimised on GPU, and is intended to scale, clip, and convert the data to a given integer's range before saving the result to images. It allows to run this on the GPU (much faster), rather than on CPU as part of `save_to_images`. 

Note, it should only be used once [this PR](https://github.com/DiamondLightSource/httomolib/pull/7) in `httomolib` has been merged.