### PR TITLE
Trigger IRIS CI workflow once for PR branch push

### DIFF
--- a/.github/workflows/tests_run.yml
+++ b/.github/workflows/tests_run.yml
@@ -1,8 +1,12 @@
 name: httomolibgpu tests on Iris
 
 on:
-  - pull_request
-  - push
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-linux:


### PR DESCRIPTION
Fixes #127

Acceptance criteria checklist:
- [x] IRIS CI workflow is only triggered once for pushes to the branch associated with this PR