### PR TITLE
Move import of RecToolsDIRCuPy and RecToolsIRCuPy to module scope

### DIFF
--- a/httomolibgpu/recon/algorithm.py
+++ b/httomolibgpu/recon/algorithm.py
@@ -29,6 +29,9 @@ nvtx = cupywrapper.nvtx
 from numpy import float32, complex64
 from typing import Optional, Type
 
+from tomobar.methodsDIR_CuPy import RecToolsDIRCuPy
+from tomobar.methodsIR_CuPy import RecToolsIRCuPy
+
 __all__ = [
     "FBP",
     "LPRec",
@@ -360,8 +363,6 @@ def _instantiate_direct_recon_class(
     Returns:
         Type[RecToolsDIRCuPy]: an instance of the direct recon class
     """
-    from tomobar.methodsDIR_CuPy import RecToolsDIRCuPy
-
     if center is None:
         center = data.shape[2] // 2  # making a crude guess
     if recon_size is None:
@@ -400,8 +401,6 @@ def _instantiate_iterative_recon_class(
     Returns:
         Type[RecToolsIRCuPy]: an instance of the iterative class
     """
-    from tomobar.methodsIR_CuPy import RecToolsIRCuPy
-
     if center is None:
         center = data.shape[2] // 2  # making a crude guess
     if recon_size is None:


### PR DESCRIPTION
This PR moves import of `RecToolsDIRCuPy` and `RecToolsIRCuPy` into module scope, instead of function scope.

Not only this is a more Pythonic style, but most importantly, it avoids duplicated references of input `data` and the output reconstruction. Importing `RecToolsDIRCuPy` and `RecToolsIRCuPy` inside the function seems creating unnecessary references of their CuPy arrays when the functions return to the caller. By importing at the module scope, this duplication of references is not present and ensure proper clean-up by the CuPy memory pool upstream.