### PR TITLE
Add Dockerfile and corresponding workflow

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,45 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - "dockerfile"
+  workflow_dispatch:
+
+jobs:
+  build-and-push-image:
+    if: ${{ github.repository == 'DiamondLightSource/httomolibgpu' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=edge,branch=main
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM nvidia/cuda:11.6.2-devel-ubi8
+
+RUN dnf install -y git && \
+    dnf clean all


### PR DESCRIPTION
This is an attempt to build and push a docker image to the GitHub container registry using `nvidia/cuda:11.6.2-devel-ubi8` as a base image. This newly built image can then be used for our GA workflows.