### PR TITLE
Update CUDA container version for IRIS CI tests

### DIFF
--- a/.github/workflows/httomolibgpu_tests_run_iris.yml
+++ b/.github/workflows/httomolibgpu_tests_run_iris.yml
@@ -11,7 +11,7 @@ jobs:
   iris-gpu:
     runs-on: iris-gpu
     container:
-      image: nvidia/cuda:11.6.2-devel-ubi8
+      image: nvidia/cuda:12.6.3-devel-ubi8
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
 


### PR DESCRIPTION
Tentatively updating CUDA version due to seeing that this somehow got rid of the cupy/CUDA errors appearing in https://github.com/DiamondLightSource/httomo-backends/pull/6