### PR TITLE
modified the docstring for find_center_pc and data_resampler methods,…

### DIFF
--- a/httomolibgpu/misc/morph.py
+++ b/httomolibgpu/misc/morph.py
@@ -104,21 +104,29 @@ def sino_360_to_180(
 def data_resampler(
     data: cp.ndarray, newshape: list, axis: int = 1, interpolation: str = "linear"
 ) -> cp.ndarray:
-    """Down/Up-resampler of the input data implemented through interpn function.
-       Please note that the method will leave the specified axis
-       dimension unchanged, e.g. (128,128,128) -> (128,256,256) for axis = 0 and
-       newshape = [256,256].
+    """
+    Down/Up-resampler of the input data implemented through interpn function.
+    Please note that the method will leave the specified axis
+    dimension unchanged, e.g. (128,128,128) -> (128,256,256) for axis = 0 and
+    newshape = [256,256].
 
-    Args:
-        data (cp.ndarray): 3d cupy array.
-        newshape (list): 2d list that defines the 2D slice shape of new shape data.
-        axis (int, optional): Axis along which the scaling is applied. Defaults to 1.
-        interpolation (str, optional): Selection of interpolation method. Defaults to 'linear'.
+    Parameters
+    ----------
+    data : cp.ndarray 
+        3d cupy array.
+    newshape : list
+        2d list that defines the 2D slice shape of new shape data.
+    axis : int, optional
+        Axis along which the scaling is applied. Defaults to 1.
+    interpolation : str, optional
+        Selection of interpolation method. Defaults to 'linear'.
 
-    Raises:
+    Raises
+    ----------
         ValueError: When data is not 3D
 
-    Returns:
+    Returns
+    ----------
         cp.ndarray: Up/Down-scaled 3D cupy array
     """
     expanded = False

--- a/httomolibgpu/recon/rotation.py
+++ b/httomolibgpu/recon/rotation.py
@@ -821,21 +821,29 @@ def find_center_pc(
     tol: float = 0.5,
     rotc_guess: Union[float, Optional[str]] = None,
 ) -> float:
-    """Find rotation axis location by finding the offset between the first
+    """
+    Find rotation axis location by finding the offset between the first
     projection and a mirrored projection 180 degrees apart using
     phase correlation in Fourier space.
     The `phase_cross_correlation` function uses cross-correlation in Fourier
     space, optionally employing an upsampled matrix-multiplication DFT to
     achieve arbitrary subpixel precision. See :cite:`guizar2008efficient`.
 
-    Args:
-        proj1 (cp.ndarray): Projection from the 0th degree angle.
-        proj2 (cp.ndarray): Projection from the 180th degree angle.
-        tol (float, optional): Subpixel accuracy. Defaults to 0.5.
-        rotc_guess (float, optional): Initial guess value for the rotation center. Defaults to None.
-
-    Returns:
-        float: Rotation axis location.
+    Parameters
+    ----------
+    proj1 : cp.ndarray
+        Projection from the 0th degree angle.
+    proj2 : cp.ndarray
+        Projection from the 180th degree angle.
+    tol : float, optional
+        Subpixel accuracy. Defaults to 0.5.
+    rotc_guess : float, optional
+        Initial guess value for the rotation center. Defaults to None.
+        
+    Returns
+    ----------
+    float
+        Rotation axis location.
     """
     imgshift = 0.0 if rotc_guess is None else rotc_guess - (proj1.shape[1] - 1.0) / 2.0
 


### PR DESCRIPTION
… I realised they were in a different format compared to docstrings of other methods, that lead to the API extracting empty strings for details out of these 2 functions 