### PR TITLE
Optimise `remove_all_stripe`

### DIFF
--- a/httomolibgpu/prep/stripe.py
+++ b/httomolibgpu/prep/stripe.py
@@ -215,8 +215,13 @@ def _rs_sort2(sinogram, size, matindex, dim):
     """
     Remove stripes using the sorting technique.
     """
-    sinogram = cp.transpose(sinogram)
-    matcomb = cp.asarray(cp.dstack((matindex, sinogram)))
+    # Ensure contiguous memory for efficiency
+    sinogram = cp.ascontiguousarray(sinogram.T)
+
+    # Preallocate memory instead of using dstack()
+    matcomb = cp.empty((sinogram.shape[0], sinogram.shape[1], 2), dtype=cp.float32)
+    matcomb[:, :, 0] = matindex
+    matcomb[:, :, 1] = sinogram
 
     ids = cp.argsort(matcomb[:, :, 1], axis=1)
     matsort = matcomb.copy()

--- a/httomolibgpu/prep/stripe.py
+++ b/httomolibgpu/prep/stripe.py
@@ -205,37 +205,10 @@ def remove_all_stripe(
     for m in range(data.shape[1]):
         sino = data[:, m, :]
         sino = _rs_dead(sino, snr, la_size, matindex)
-        sino = _rs_sort2(sino, sm_size, matindex, dim)
+        sino = _rs_sort(sino, sm_size, dim)
         sino = cp.nan_to_num(sino)
         data[:, m, :] = sino
     return data
-
-
-def _rs_sort2(sinogram, size, matindex, dim):
-    """
-    Remove stripes using the sorting technique.
-    """
-    # Ensure contiguous memory for efficiency
-    sinogram = cp.ascontiguousarray(sinogram.T)
-
-    # Preallocate memory instead of using dstack()
-    matcomb = cp.empty((sinogram.shape[0], sinogram.shape[1], 2), dtype=cp.float32)
-    matcomb[:, :, 0] = matindex
-    matcomb[:, :, 1] = sinogram
-
-    ids = cp.argsort(matcomb[:, :, 1], axis=1)
-    matsort = matcomb.copy()
-    matsort[:, :, 0] = cp.take_along_axis(matsort[:, :, 0], ids, axis=1)
-    matsort[:, :, 1] = cp.take_along_axis(matsort[:, :, 1], ids, axis=1)
-    matsort[:, :, 1] = median_filter(matsort[:, :, 1], (size, 1) if dim == 1 else (size, size))
-
-    ids = cp.argsort(matsort[:, :, 0], axis=1)
-    matsortback = matsort.copy()
-    matsortback[:, :, 0] = cp.take_along_axis(matsortback[:, :, 0], ids, axis=1)
-    matsortback[:, :, 1] = cp.take_along_axis(matsortback[:, :, 1], ids, axis=1)
-
-    sino_corrected = matsortback[:, :, 1]
-    return cp.transpose(sino_corrected)
 
 
 def _mpolyfit(x, y):

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -190,6 +190,8 @@ def test_remove_all_stripe_on_data(data, flats, darks):
     )
     assert_allclose(np.median(data_after_stripe_removal), 0.015338, rtol=1e-04)
     assert_allclose(np.max(data_after_stripe_removal), 2.298123, rtol=1e-05)
+    assert_allclose(np.median(data_after_stripe_removal, axis=(1, 2)).sum(), 2.788046, rtol=1e-6)
+    assert_allclose(np.median(data_after_stripe_removal, axis=(0, 1)).sum(), 28.661312, rtol=1e-6)
 
     data = None  #: free up GPU memory
     # make sure the output is float32

--- a/zenodo-tests/test_prep/test_stripe.py
+++ b/zenodo-tests/test_prep/test_stripe.py
@@ -1,0 +1,34 @@
+import cupy as cp
+import numpy as np
+import pytest
+
+from numpy.testing import assert_allclose
+from httomolibgpu.prep.stripe import remove_all_stripe
+from httomolibgpu.prep.normalize import normalize
+from conftest import force_clean_gpu_memory
+
+
+@pytest.mark.parametrize(
+    "dataset_fixture, exp_sum, mean, mean_sum, med_sum, _med_sum, shape",
+    [
+        ("i13_dataset1", 32071604.0, 0.208765, 1252.7957, 529.2594, 1254.792, (6001, 10, 2560)),
+        ("i13_dataset3", 27234604.0, 0.59093, 3546.1704, 1500.7285, 3531.5493, (6001, 3, 2560)),
+    ],
+    ids=["dataset_one", "dataset_three"],
+)
+def test_remove_all_stripe_with_i13_data(
+    request, dataset_fixture, exp_sum, mean, mean_sum, med_sum, _med_sum, shape
+):
+    dataset = request.getfixturevalue(dataset_fixture)
+    data_normalised = normalize(dataset[0], dataset[2], dataset[3], minus_log=True)
+    output = remove_all_stripe(cp.copy(data_normalised)).get()
+
+    assert_allclose(np.sum(output), exp_sum, rtol=1e-07, atol=1e-6)
+    assert_allclose(np.mean(output), mean, rtol=1e-07, atol=1e-6)
+    assert_allclose(np.mean(output, axis=(1, 2)).sum(), mean_sum, rtol=1e-06)
+    assert_allclose(np.median(output, axis=(0, 1)).sum(), med_sum, rtol=1e-06)
+    assert_allclose(np.median(output, axis=(1, 2)).sum(), _med_sum, rtol=1e-6)
+    force_clean_gpu_memory()
+    assert output.shape == shape
+    assert output.dtype == np.float32
+    assert output.flags.c_contiguous

--- a/zenodo-tests/test_recon/test_algorithm.py
+++ b/zenodo-tests/test_recon/test_algorithm.py
@@ -38,7 +38,7 @@ def test_reconstruct_FBP_i12_dataset1(i12_dataset1):
     )
     assert recon_data.flags.c_contiguous
     recon_data = recon_data.get()
-    assert_allclose(np.sum(recon_data), 46569.395, rtol=1e-07, atol=1e-6)
+    assert_allclose(np.sum(recon_data), 46569.402, rtol=1e-07, atol=1e-6)
     assert recon_data.dtype == np.float32
     assert recon_data.shape == (2560, 50, 2560)
 

--- a/zenodo-tests/test_recon/test_algorithm.py
+++ b/zenodo-tests/test_recon/test_algorithm.py
@@ -38,7 +38,7 @@ def test_reconstruct_FBP_i12_dataset1(i12_dataset1):
     )
     assert recon_data.flags.c_contiguous
     recon_data = recon_data.get()
-    assert_allclose(np.sum(recon_data), 46569.402, rtol=1e-07, atol=1e-6)
+    assert_allclose(np.sum(recon_data), 46569.39, rtol=1e-07, atol=1e-6)
     assert recon_data.dtype == np.float32
     assert recon_data.shape == (2560, 50, 2560)
 


### PR DESCRIPTION
**Before optimisation**

Using 100 slices  with 28a17ed31c2dec58bc36994f7ee98b9acb27799f (and Tesla V100S-PCIE-32GB Wilson)

```console
AssertionError: assert 'performance in ms' == 3609.8993619000003
```

The benchmarking plot looks like

![image](https://github.com/user-attachments/assets/451a61e0-d3af-449c-93e3-5b32664b5150)

Compute Only: GPU implementation (taken from TomoCuPy) is **5.6x** faster than the CPU implementation (from TomoPy)