### PR TITLE
Add remove_stripe_fw with memory peak calculator

### DIFF
--- a/docs/source/bibliography/references.bib
+++ b/docs/source/bibliography/references.bib
@@ -160,3 +160,14 @@
   year={2009},
   publisher={SIAM}
 }
+
+@article{munch2009stripe,
+  title={Stripe and ring artifact removal with combined wavelet—Fourier filtering},
+  author={M{\"u}nch, Beat and Trtik, Pavel and Marone, Federica and Stampanoni, Marco},
+  journal={Optics express},
+  volume={17},
+  number={10},
+  pages={8567--8591},
+  year={2009},
+  publisher={Optical Society of America}
+}

--- a/httomolibgpu/__init__.py
+++ b/httomolibgpu/__init__.py
@@ -9,6 +9,7 @@ from httomolibgpu.prep.normalize import dark_flat_field_correction, minus_log
 from httomolibgpu.prep.phase import paganin_filter, paganin_filter_savu_legacy
 from httomolibgpu.prep.stripe import (
     remove_stripe_based_sorting,
+    remove_stripe_fw,
     remove_stripe_ti,
     remove_all_stripe,
     raven_filter,

--- a/httomolibgpu/cuda_kernels/remove_stripe_fw.cu
+++ b/httomolibgpu/cuda_kernels/remove_stripe_fw.cu
@@ -1,5 +1,5 @@
 template<int WSize>
-__global__ void double_convolution_x(
+__global__ void grouped_convolution_x(
     int dim_x,
     int dim_y,
     int dim_z,
@@ -32,12 +32,12 @@ __global__ void double_convolution_x(
             acc += w[w_idx] * in[in_idx];
         }
         const int out_idx = g_thd_x + g_thd_y * dim_x + g_thd_z * out_stride_z + i * out_stride_group;
-        out[out_idx] += acc;
+        out[out_idx] = acc;
     }
 }
 
 template<int WSize>
-__global__ void double_convolution_y(
+__global__ void grouped_convolution_y(
     int dim_x,
     int dim_y,
     int dim_z,
@@ -75,8 +75,81 @@ __global__ void double_convolution_y(
                 acc += w[w_idx] * in[in_idx];
             }
             const int out_idx = g_thd_x + g_thd_y * dim_x + g_thd_z * out_stride_z + (out_groups * group + i) * out_stride_group;
-            out[out_idx] += acc;
+            out[out_idx] = acc;
         }
     }
 }
 
+template<int WSize>
+__global__ void transposed_convolution_x(
+    int dim_x,
+    int dim_y,
+    int dim_z,
+    const float* in,
+    int in_dim_x,
+    int in_stride_y,
+    int in_stride_z,
+    const float* w,
+    float* out
+)
+{
+    const int g_thd_x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int g_thd_y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int g_thd_z = blockDim.z * blockIdx.z + threadIdx.z;
+    if (g_thd_x >= dim_x || g_thd_y >= dim_y || g_thd_z >= dim_z)
+    {
+        return;
+    }
+
+    constexpr int item_out_stride = 2;
+    float acc = 0.F;
+    for (int i = 0; i < WSize; ++i)
+    {
+        const int in_x = (g_thd_x - i) / item_out_stride;
+        const int in_x_mod = (g_thd_x - i) % item_out_stride;
+        if (in_x_mod == 0 && in_x >= 0 && in_x < in_dim_x)
+        {
+            const int in_idx = in_x + g_thd_y * in_stride_y + g_thd_z * in_stride_z;
+            acc += in[in_idx] * w[i];
+        }
+    }
+    const int out_idx = g_thd_x + dim_x * g_thd_y + dim_x * dim_y * g_thd_z;
+    out[out_idx] = acc;
+}
+
+template<int WSize>
+__global__ void transposed_convolution_y(
+    int dim_x,
+    int dim_y,
+    int dim_z,
+    const float* in,
+    int in_dim_y,
+    int in_stride_y,
+    int in_stride_z,
+    const float* w,
+    float* out
+)
+{
+    const int g_thd_x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int g_thd_y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int g_thd_z = blockDim.z * blockIdx.z + threadIdx.z;
+    if (g_thd_x >= dim_x || g_thd_y >= dim_y || g_thd_z >= dim_z)
+    {
+        return;
+    }
+
+    constexpr int item_out_stride = 2;
+    float acc = 0.F;
+    for (int i = 0; i < WSize; ++i)
+    {
+        const int in_y = (g_thd_y - i) / item_out_stride;
+        const int in_y_mod = (g_thd_y - i) % item_out_stride;
+        if (in_y_mod == 0 && in_y >= 0 && in_y < in_dim_y)
+        {
+            const int in_idx = g_thd_x + in_y * in_stride_y + g_thd_z * in_stride_z;
+            acc += in[in_idx] * w[i];
+        }
+    }
+    const int out_idx = g_thd_x + dim_x * g_thd_y + dim_x * dim_y * g_thd_z;
+    out[out_idx] = acc;
+}

--- a/httomolibgpu/cuda_kernels/remove_stripe_fw.cu
+++ b/httomolibgpu/cuda_kernels/remove_stripe_fw.cu
@@ -1,0 +1,82 @@
+template<int WSize>
+__global__ void double_convolution_x(
+    int dim_x,
+    int dim_y,
+    int dim_z,
+    const float* in,
+    int in_stride_x,
+    int in_stride_y,
+    int in_stride_z,
+    float* out,
+    int out_stride_z,
+    int out_stride_group,
+    const float* w
+)
+{
+    const int g_thd_x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int g_thd_y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int g_thd_z = blockDim.z * blockIdx.z + threadIdx.z;
+    if (g_thd_x >= dim_x || g_thd_y >= dim_y || g_thd_z >= dim_z)
+    {
+        return;
+    }
+
+    constexpr int out_groups = 2;
+    for (int i = 0; i < out_groups; ++i)
+    {
+        float acc = 0.F;
+        for (int j = 0; j < WSize; ++j)
+        {
+            const int w_idx = i * WSize + j;
+            const int in_idx = (g_thd_x * in_stride_x + j) + g_thd_y * in_stride_y + g_thd_z * in_stride_z;
+            acc += w[w_idx] * in[in_idx];
+        }
+        const int out_idx = g_thd_x + g_thd_y * dim_x + g_thd_z * out_stride_z + i * out_stride_group;
+        out[out_idx] += acc;
+    }
+}
+
+template<int WSize>
+__global__ void double_convolution_y(
+    int dim_x,
+    int dim_y,
+    int dim_z,
+    const float* in,
+    int in_stride_x,
+    int in_stride_y,
+    int in_stride_z,
+    int in_stride_group,
+    float* out,
+    int out_stride_z,
+    int out_stride_group,
+    const float* w
+)
+{
+    const int g_thd_x = blockDim.x * blockIdx.x + threadIdx.x;
+    const int g_thd_y = blockDim.y * blockIdx.y + threadIdx.y;
+    const int g_thd_z = blockDim.z * blockIdx.z + threadIdx.z;
+    if (g_thd_x >= dim_x || g_thd_y >= dim_y || g_thd_z >= dim_z)
+    {
+        return;
+    }
+
+    constexpr int in_groups = 2;
+    constexpr int out_groups = 2;
+    constexpr int item_stride_y = 2;
+    for (int group = 0; group < in_groups; ++group)
+    {
+        for (int i = 0; i < out_groups; ++i)
+        {
+            float acc = 0.F;
+            for (int j = 0; j < WSize; ++j)
+            {
+                const int w_idx = (out_groups * group + i) * WSize + j;
+                const int in_idx = g_thd_x * in_stride_x + (item_stride_y * g_thd_y + j) * in_stride_y + group * in_stride_group + g_thd_z * in_stride_z;
+                acc += w[w_idx] * in[in_idx];
+            }
+            const int out_idx = g_thd_x + g_thd_y * dim_x + g_thd_z * out_stride_z + (out_groups * group + i) * out_stride_group;
+            out[out_idx] += acc;
+        }
+    }
+}
+

--- a/httomolibgpu/prep/stripe.py
+++ b/httomolibgpu/prep/stripe.py
@@ -621,10 +621,11 @@ def _repair_memory_fragmentation_if_needed(fragmentation_threshold: float = 0.2)
     if (total / pool.used_bytes()) - 1 > fragmentation_threshold:
         pool.free_all_blocks()
 
+
 def remove_stripe_fw(
     data: cp.ndarray,
-    sigma: float = 1,
-    wname: str = "sym16",
+    sigma: float = 2,
+    wname: str = "db5",
     level: Optional[int] = None,
     calc_peak_gpu_mem: bool = False,
 ) -> cp.ndarray:
@@ -639,7 +640,7 @@ def remove_stripe_fw(
     sigma : float
         Damping parameter in Fourier space.
     wname : str
-        Type of the wavelet filter: select from 'haar', 'db4', 'sym5', 'sym16' 'bior4.4'.
+        Type of the wavelet filter: select from 'db5', 'db7', 'haar', 'sym5', 'sym16' 'bior4.4'.
     level : int, optional
         Number of discrete wavelet transform levels.
     calc_peak_gpu_mem: str:
@@ -693,7 +694,7 @@ def remove_stripe_fw(
             mem_stack.malloc(2 * np.prod(fcV_shape) * np.float32().itemsize)
             mem_stack.malloc(2 * fcV_bytes)
 
-            fft_dummy = cp.empty(fcV_shape, dtype='float32')
+            fft_dummy = cp.empty(fcV_shape, dtype="float32")
             fft_plan = get_fft_plan(fft_dummy)
             fft_plan_size = fft_plan.work_area.mem.size
             del fft_dummy

--- a/httomolibgpu/prep/stripe.py
+++ b/httomolibgpu/prep/stripe.py
@@ -21,6 +21,7 @@
 """Module for stripes removal"""
 
 import numpy as np
+import pywt
 from httomolibgpu import cupywrapper
 
 cp = cupywrapper.cp
@@ -45,6 +46,7 @@ from typing import Union
 
 __all__ = [
     "remove_stripe_based_sorting",
+    "remove_stripe_fw",
     "remove_stripe_ti",
     "remove_all_stripe",
     "raven_filter",
@@ -154,6 +156,320 @@ def remove_stripe_ti(
         return data[:, :, :-1]
     else:
         return data
+
+
+###### Ring removal with wavelet filtering (adapted for cupy from pytroch_wavelet package https://pytorch-wavelets.readthedocs.io/)##########
+# These functions are taken from TomoCuPy package
+# *************************************************************************** #
+#                  Copyright © 2022, UChicago Argonne, LLC                    #
+#                           All Rights Reserved                               #
+#                         Software Name: Tomocupy                             #
+#                     By: Argonne National Laboratory                         #
+#                                                                             #
+#                           OPEN SOURCE LICENSE                               #
+#                                                                             #
+# Redistribution and use in source and binary forms, with or without          #
+# modification, are permitted provided that the following conditions are met: #
+#                                                                             #
+# 1. Redistributions of source code must retain the above copyright notice,   #
+#    this list of conditions and the following disclaimer.                    #
+# 2. Redistributions in binary form must reproduce the above copyright        #
+#    notice, this list of conditions and the following disclaimer in the      #
+#    documentation and/or other materials provided with the distribution.     #
+# 3. Neither the name of the copyright holder nor the names of its            #
+#    contributors may be used to endorse or promote products derived          #
+#    from this software without specific prior written permission.            #
+#                                                                             #
+#                                                                             #
+# *************************************************************************** #
+
+def _reflect(x, minx, maxx):
+    """Reflect the values in matrix *x* about the scalar values *minx* and
+    *maxx*.  Hence a vector *x* containing a long linearly increasing series is
+    converted into a waveform which ramps linearly up and down between *minx*
+    and *maxx*.  If *x* contains integers and *minx* and *maxx* are (integers +
+    0.5), the ramps will have repeated max and min samples.
+
+    .. codeauthor:: Rich Wareham <rjw57@cantab.net>, Aug 2013
+    .. codeauthor:: Nick Kingsbury, Cambridge University, January 1999.
+
+    """
+    x = cp.asanyarray(x)
+    rng = maxx - minx
+    rng_by_2 = 2 * rng
+    mod = cp.fmod(x - minx, rng_by_2)
+    normed_mod = cp.where(mod < 0, mod + rng_by_2, mod)
+    out = cp.where(normed_mod >= rng, rng_by_2 - normed_mod, normed_mod) + minx
+    return cp.array(out, dtype=x.dtype)
+
+
+def _mypad(x, pad, value=0):
+    """ Function to do numpy like padding on Arrays. Only works for 2-D
+    padding.
+
+    Inputs:
+        x (array): Array to pad
+        pad (tuple): tuple of (left, right, top, bottom) pad sizes        
+    """
+    # Vertical only
+    if pad[0] == 0 and pad[1] == 0:
+        m1, m2 = pad[2], pad[3]
+        l = x.shape[-2]
+        xe = _reflect(cp.arange(-m1, l+m2, dtype='int32'), -0.5, l-0.5)
+        return x[:, :, xe]
+    # horizontal only
+    elif pad[2] == 0 and pad[3] == 0:
+        m1, m2 = pad[0], pad[1]
+        l = x.shape[-1]
+        xe = _reflect(cp.arange(-m1, l+m2, dtype='int32'), -0.5, l-0.5)
+        return x[:, :, :, xe]
+
+
+def _conv2d(x, w, stride, pad, groups=1):
+    """ Convolution (equivalent pytorch.conv2d)
+    """
+    if pad != 0:
+        x = cp.pad(x, ((0, 0), (0, 0), (pad, pad), (pad, pad)), 'constant')
+
+    b,  ci, hi, wi = x.shape
+    co, _, hk, wk = w.shape
+    ho = int(cp.floor(1 + (hi - hk) / stride[0]))
+    wo = int(cp.floor(1 + (wi - wk) / stride[1]))
+    out = cp.zeros([b, co, ho, wo], dtype='float32')
+    x = cp.expand_dims(x, axis=1)
+    w = cp.expand_dims(w, axis=0)
+    chunk = ci//groups
+    chunko = co//groups
+    for g in range(groups):
+        for ii in range(hk):
+            for jj in range(wk):
+                x_windows = x[:, :, g*chunk:(g+1)*chunk, ii:ho *
+                              stride[0]+ii:stride[0], jj:wo*stride[1]+jj:stride[1]]
+                out[:, g*chunko:(g+1)*chunko] += cp.sum(x_windows *
+                                                        w[:, g*chunko:(g+1)*chunko, :, ii:ii+1, jj:jj+1], axis=2)
+    return out
+
+
+def _conv_transpose2d(x, w, stride, pad, bias=None, groups=1):
+    """ Transposed convolution (equivalent pytorch.conv_transpose2d)
+    """
+    b,  co, ho, wo = x.shape
+    co, ci, hk, wk = w.shape
+
+    hi = (ho-1)*stride[0]+hk
+    wi = (wo-1)*stride[1]+wk
+    out = cp.zeros([b, ci, hi, wi], dtype='float32')
+    chunk = ci//groups
+    chunko = co//groups
+    for g in range(groups):
+        for ii in range(hk):
+            for jj in range(wk):
+                x_windows = x[:, g*chunko:(g+1)*chunko]
+                out[:, g*chunk:(g+1)*chunk, ii:ho*stride[0]+ii:stride[0], jj:wo*stride[1] +
+                    jj:stride[1]] += x_windows * w[g*chunko:(g+1)*chunko, :, ii:ii+1, jj:jj+1]
+    if pad != 0:
+        out = out[:, :, pad[0]:out.shape[2]-pad[0], pad[1]:out.shape[3]-pad[1]]
+    return out
+
+
+def afb1d(x, h0, h1='zero', dim=-1):
+    """ 1D analysis filter bank (along one dimension only) of an image
+
+    Parameters
+    ----------
+    x (array): 4D input with the last two dimensions the spatial input
+    h0 (array): 4D input for the lowpass filter. Should have shape (1, 1,
+        h, 1) or (1, 1, 1, w)
+    h1 (array): 4D input for the highpass filter. Should have shape (1, 1,
+        h, 1) or (1, 1, 1, w)
+    dim (int) - dimension of filtering. d=2 is for a vertical filter (called
+        column filtering but filters across the rows). d=3 is for a
+        horizontal filter, (called row filtering but filters across the
+        columns).
+
+    Returns
+    -------
+    lohi: lowpass and highpass subbands concatenated along the channel
+        dimension
+    """
+    C = x.shape[1]
+    # Convert the dim to positive
+    d = dim % 4
+    s = (2, 1) if d == 2 else (1, 2)
+    N = x.shape[d]
+    L = h0.size
+    L2 = L // 2
+    shape = [1, 1, 1, 1]
+    shape[d] = L
+    h = cp.concatenate([h0.reshape(*shape), h1.reshape(*shape)]*C, axis=0)
+    # Calculate the pad size
+    outsize = pywt.dwt_coeff_len(N, L, mode='symmetric')
+    p = 2 * (outsize - 1) - N + L
+    pad = (0, 0, p//2, (p+1)//2) if d == 2 else (p//2, (p+1)//2, 0, 0)
+    x = _mypad(x, pad=pad)
+    lohi = _conv2d(x, h, stride=s, pad=0, groups=C)
+    return lohi
+
+
+def sfb1d(lo, hi, g0, g1='zero', dim=-1):
+    """ 1D synthesis filter bank of an image Array
+    """
+
+    C = lo.shape[1]
+    d = dim % 4
+    L = g0.size
+    shape = [1, 1, 1, 1]
+    shape[d] = L
+    N = 2*lo.shape[d]
+    s = (2, 1) if d == 2 else (1, 2)
+    g0 = cp.concatenate([g0.reshape(*shape)]*C, axis=0)
+    g1 = cp.concatenate([g1.reshape(*shape)]*C, axis=0)
+    pad = (L-2, 0) if d == 2 else (0, L-2)
+    y = _conv_transpose2d(cp.asarray(lo), cp.asarray(g0), stride=s, pad=pad, groups=C) + \
+        _conv_transpose2d(cp.asarray(hi), cp.asarray(g1),
+                          stride=s, pad=pad, groups=C)
+    return y
+
+
+class DWTForward():
+    """ Performs a 2d DWT Forward decomposition of an image
+
+    Args:
+        wave (str): Which wavelet to use.                    
+        """
+
+    def __init__(self, wave='db1'):
+        super().__init__()
+
+        wave = pywt.Wavelet(wave)
+        h0_col, h1_col = wave.dec_lo, wave.dec_hi
+        h0_row, h1_row = h0_col, h1_col
+
+        self.h0_col = cp.array(h0_col).astype('float32')[
+            ::-1].reshape((1, 1, -1, 1))
+        self.h1_col = cp.array(h1_col).astype('float32')[
+            ::-1].reshape((1, 1, -1, 1))
+        self.h0_row = cp.array(h0_row).astype('float32')[
+            ::-1].reshape((1, 1, 1, -1))
+        self.h1_row = cp.array(h1_row).astype('float32')[
+            ::-1].reshape((1, 1, 1, -1))
+
+    def apply(self, x):
+        """ Forward pass of the DWT.
+
+        Args:
+            x (array): Input of shape :math:`(N, C_{in}, H_{in}, W_{in})`
+
+        Returns:
+            (yl, yh)
+                tuple of lowpass (yl) and bandpass (yh) coefficients.
+                yh is a list of scale coefficients. yl has shape
+                :math:`(N, C_{in}, H_{in}', W_{in}')` and yh has shape
+                :math:`list(N, C_{in}, 3, H_{in}'', W_{in}'')`. The new
+                dimension in yh iterates over the LH, HL and HH coefficients.
+
+        Note:
+            :math:`H_{in}', W_{in}', H_{in}'', W_{in}''` denote the correctly
+            downsampled shapes of the DWT pyramid.
+        """
+        # Do a multilevel transform
+        # Do 1 level of the transform
+        lohi = afb1d(x, self.h0_row, self.h1_row, dim=3)
+        y = afb1d(lohi, self.h0_col, self.h1_col, dim=2)
+        s = y.shape
+        y = y.reshape(s[0], -1, 4, s[-2], s[-1])
+        x = cp.ascontiguousarray(y[:, :, 0])
+        yh = cp.ascontiguousarray(y[:, :, 1:])
+        return x, yh
+
+
+class DWTInverse():
+    """ Performs a 2d DWT Inverse reconstruction of an image
+
+    Args:
+        wave (str): Which wavelet to use.            
+    """
+
+    def __init__(self, wave='db1'):
+        super().__init__()
+        wave = pywt.Wavelet(wave)
+        g0_col, g1_col = wave.rec_lo, wave.rec_hi
+        g0_row, g1_row = g0_col, g1_col
+        # Prepare the filters
+        self.g0_col = cp.array(g0_col).astype('float32').reshape((1, 1, -1, 1))
+        self.g1_col = cp.array(g1_col).astype('float32').reshape((1, 1, -1, 1))
+        self.g0_row = cp.array(g0_row).astype('float32').reshape((1, 1, 1, -1))
+        self.g1_row = cp.array(g1_row).astype('float32').reshape((1, 1, 1, -1))
+
+    def apply(self, coeffs):
+        """
+        Args:
+            coeffs (yl, yh): tuple of lowpass and bandpass coefficients, where:
+              yl is a lowpass array of shape :math:`(N, C_{in}, H_{in}',
+              W_{in}')` and yh is a list of bandpass arrays of shape
+              :math:`list(N, C_{in}, 3, H_{in}'', W_{in}'')`. I.e. should match
+              the format returned by DWTForward
+
+        Returns:
+            Reconstructed input of shape :math:`(N, C_{in}, H_{in}, W_{in})`
+
+        Note:
+            :math:`H_{in}', W_{in}', H_{in}'', W_{in}''` denote the correctly
+            downsampled shapes of the DWT pyramid.
+
+        """
+        yl, yh = coeffs
+        lh = yh[:, :, 0]
+        hl = yh[:, :, 1]
+        hh = yh[:, :, 2]
+        lo = sfb1d(yl, lh, self.g0_col, self.g1_col, dim=2)
+        hi = sfb1d(hl, hh, self.g0_col, self.g1_col, dim=2)
+        yl = sfb1d(lo, hi, self.g0_row, self.g1_row, dim=3)
+        return yl
+
+
+def remove_stripe_fw(data, sigma=1, wname='sym16', level=7):
+    """Remove stripes with wavelet filtering"""
+
+    [nproj, nz, ni] = data.shape
+
+    nproj_pad = nproj + nproj // 8
+    xshift = int((nproj_pad - nproj) // 2)
+
+    # Accepts all wave types available to PyWavelets
+    xfm = DWTForward(wave=wname)
+    ifm = DWTInverse(wave=wname)
+
+    # Wavelet decomposition.
+    cc = []
+    sli = cp.zeros([nz, 1, nproj_pad, ni], dtype='float32')
+
+    sli[:, 0, (nproj_pad - nproj)//2:(nproj_pad + nproj) //
+        2] = data.astype('float32').swapaxes(0, 1)
+    for k in range(level):
+        sli, c = xfm.apply(sli)
+        cc.append(c)
+        # FFT
+        fcV = cp.fft.fft(cc[k][:, 0, 1], axis=1)
+        _, my, mx = fcV.shape
+        # Damping of ring artifact information.
+        y_hat = cp.fft.ifftshift((cp.arange(-my, my, 2) + 1) / 2)
+        damp = -cp.expm1(-y_hat**2 / (2 * sigma**2))
+        fcV *= cp.tile(damp, (mx, 1)).swapaxes(0, 1)
+        # Inverse FFT.
+        cc[k][:, 0, 1] = cp.fft.ifft(fcV, my, axis=1).real
+
+    # Wavelet reconstruction.
+    for k in range(level)[::-1]:
+        shape0 = cc[k][0, 0, 1].shape
+        sli = sli[:, :, :shape0[0], :shape0[1]]
+        sli = ifm.apply((sli, cc[k]))
+
+    data = sli[:, 0, (nproj_pad - nproj)//2:(nproj_pad + nproj) //
+               2, :ni].astype(data.dtype)  # modified
+    data = data.swapaxes(0, 1)
+
+    return data
 
 
 ######## Optimized version for Vo-all ring removal in tomopy########

--- a/httomolibgpu/prep/stripe.py
+++ b/httomolibgpu/prep/stripe.py
@@ -644,7 +644,7 @@ def remove_stripe_fw(
     level : int, optional
         Number of discrete wavelet transform levels.
     calc_peak_gpu_mem: str:
-        Supporting parameter for memory calculation in HTTomo.
+        Parameter to support memory estimation in HTTomo. Irrelevant to the method itself and can be ignored by user.
 
     Returns
     -------

--- a/httomolibgpu/prep/stripe.py
+++ b/httomolibgpu/prep/stripe.py
@@ -203,7 +203,7 @@ def _reflect(x, minx, maxx):
     return cp.array(out, dtype=x.dtype)
 
 
-def _mypad(x, pad, value=0):
+def _mypad(x, pad):
     """ Function to do numpy like padding on Arrays. Only works for 2-D
     padding.
 
@@ -225,7 +225,7 @@ def _mypad(x, pad, value=0):
         return x[:, :, :, xe]
 
 
-def _conv2d(x, w, stride, pad, groups=1):
+def _conv2d(x, w, stride, pad, groups):
     """ Convolution (equivalent pytorch.conv2d)
     """
     if pad != 0:
@@ -250,7 +250,7 @@ def _conv2d(x, w, stride, pad, groups=1):
     return out
 
 
-def _conv_transpose2d(x, w, stride, pad, bias=None, groups=1):
+def _conv_transpose2d(x, w, stride, pad, groups):
     """ Transposed convolution (equivalent pytorch.conv_transpose2d)
     """
     b,  co, ho, wo = x.shape
@@ -272,7 +272,7 @@ def _conv_transpose2d(x, w, stride, pad, bias=None, groups=1):
     return out
 
 
-def afb1d(x, h0, h1='zero', dim=-1):
+def afb1d(x, h0, h1, dim):
     """ 1D analysis filter bank (along one dimension only) of an image
 
     Parameters
@@ -298,7 +298,6 @@ def afb1d(x, h0, h1='zero', dim=-1):
     s = (2, 1) if d == 2 else (1, 2)
     N = x.shape[d]
     L = h0.size
-    L2 = L // 2
     shape = [1, 1, 1, 1]
     shape[d] = L
     h = cp.concatenate([h0.reshape(*shape), h1.reshape(*shape)]*C, axis=0)
@@ -311,7 +310,7 @@ def afb1d(x, h0, h1='zero', dim=-1):
     return lohi
 
 
-def sfb1d(lo, hi, g0, g1='zero', dim=-1):
+def sfb1d(lo, hi, g0, g1, dim):
     """ 1D synthesis filter bank of an image Array
     """
 
@@ -320,7 +319,6 @@ def sfb1d(lo, hi, g0, g1='zero', dim=-1):
     L = g0.size
     shape = [1, 1, 1, 1]
     shape[d] = L
-    N = 2*lo.shape[d]
     s = (2, 1) if d == 2 else (1, 2)
     g0 = cp.concatenate([g0.reshape(*shape)]*C, axis=0)
     g1 = cp.concatenate([g1.reshape(*shape)]*C, axis=0)
@@ -338,7 +336,7 @@ class DWTForward():
         wave (str): Which wavelet to use.                    
         """
 
-    def __init__(self, wave='db1'):
+    def __init__(self, wave):
         super().__init__()
 
         wave = pywt.Wavelet(wave)
@@ -390,7 +388,7 @@ class DWTInverse():
         wave (str): Which wavelet to use.            
     """
 
-    def __init__(self, wave='db1'):
+    def __init__(self, wave):
         super().__init__()
         wave = pywt.Wavelet(wave)
         g0_col, g1_col = wave.rec_lo, wave.rec_hi
@@ -434,7 +432,6 @@ def remove_stripe_fw(data, sigma=1, wname='sym16', level=7):
     [nproj, nz, ni] = data.shape
 
     nproj_pad = nproj + nproj // 8
-    xshift = int((nproj_pad - nproj) // 2)
 
     # Accepts all wave types available to PyWavelets
     xfm = DWTForward(wave=wname)

--- a/httomolibgpu/prep/stripe.py
+++ b/httomolibgpu/prep/stripe.py
@@ -554,6 +554,7 @@ def remove_stripe_fw(data: cp.ndarray, sigma: float=1, wname: str='sym16', level
             sli_shape = new_sli_shape
         for c in cc:
             mem_stack.free(np.prod(c) * np.float32().itemsize)
+        mem_stack.malloc(np.prod(data) * np.float32().itemsize)
         mem_stack.free(np.prod(sli_shape) * np.float32().itemsize)
         return
 
@@ -580,8 +581,7 @@ def remove_stripe_fw(data: cp.ndarray, sigma: float=1, wname: str='sym16', level
 
     data = sli[:, 0, (nproj_pad - nproj)//2:(nproj_pad + nproj) // 2, :ni]
     data = data.swapaxes(0, 1)
-
-    return data
+    return cp.ascontiguousarray(data)
 
 
 ######## Optimized version for Vo-all ring removal in tomopy########

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pillow",
     "scikit-image",
     "tomobar",
+    "PyWavelets",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -110,12 +110,12 @@ def test_remove_stripe_fw_calc_mem(slices, level, dim_x, wname, ensure_clean_mem
 
 @pytest.mark.parametrize("wname", ["haar", "db4", "sym5", "sym16", "bior4.4"])
 @pytest.mark.parametrize(
-    "slices", [177, 239, 320, 490, 607, 803, 859, 902, 951, 1019, 1074, 1105]
+    "slices", [38, 177, 239, 320, 490, 607, 803, 859, 902, 951, 1019, 1074, 1105]
 )
 @pytest.mark.parametrize("level", [None, 7, 11])
-def test_remove_stripe_fw_calc_mem_big(wname, slices, level, ensure_clean_memory):
-    dim_y = 901
-    dim_x = 1200
+@pytest.mark.parametrize("dims", [(901, 1200), (1801, 2560)])
+def test_remove_stripe_fw_calc_mem_big(wname, slices, level, dims, ensure_clean_memory):
+    dim_y, dim_x = dims
     data_shape = (slices, dim_x, dim_y)
     try:
         estimated_mem_peak = remove_stripe_fw(

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -85,10 +85,11 @@ def ensure_clean_memory():
     cache.clear()
 
 
+@pytest.mark.parametrize("wname", ["haar", "db4", "sym5", "sym16", "bior4.4"])
 @pytest.mark.parametrize("slices", [55, 80])
 @pytest.mark.parametrize("level", [1, 3, 7, 11])
 @pytest.mark.parametrize("dim_x", [128, 140])
-def test_remove_stripe_fw_calc_mem(slices, level, dim_x, ensure_clean_memory):
+def test_remove_stripe_fw_calc_mem(slices, level, dim_x, wname, ensure_clean_memory):
     dim_y = 159
     data = cp.random.random_sample((slices, dim_x, dim_y), dtype=np.float32)
     hook = MaxMemoryHook()
@@ -98,7 +99,9 @@ def test_remove_stripe_fw_calc_mem(slices, level, dim_x, ensure_clean_memory):
 
     hook = MaxMemoryHook()
     with hook:
-        estimated_mem_peak = remove_stripe_fw(data.shape, level=level, calc_peak_gpu_mem=True)
+        estimated_mem_peak = remove_stripe_fw(
+            data.shape, level=level, wname=wname, calc_peak_gpu_mem=True
+        )
     assert hook.max_mem == 0
 
     assert actual_mem_peak * 0.99 <= estimated_mem_peak

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -109,7 +109,9 @@ def test_remove_stripe_fw_calc_mem(slices, level, dim_x, wname, ensure_clean_mem
 
 
 @pytest.mark.parametrize("wname", ["haar", "db4", "sym5", "sym16", "bior4.4"])
-@pytest.mark.parametrize("slices", [177, 239, 320, 490, 607, 803, 859, 902, 951, 1019, 1074, 1105])
+@pytest.mark.parametrize(
+    "slices", [177, 239, 320, 490, 607, 803, 859, 902, 951, 1019, 1074, 1105]
+)
 @pytest.mark.parametrize("level", [None, 7, 11])
 def test_remove_stripe_fw_calc_mem_big(wname, slices, level, ensure_clean_memory):
     dim_y = 901
@@ -117,7 +119,9 @@ def test_remove_stripe_fw_calc_mem_big(wname, slices, level, ensure_clean_memory
     data_shape = (slices, dim_x, dim_y)
     hook = MaxMemoryHook()
     with hook:
-        estimated_mem_peak = remove_stripe_fw(data_shape, wname=wname, level=level, calc_peak_gpu_mem=True)
+        estimated_mem_peak = remove_stripe_fw(
+            data_shape, wname=wname, level=level, calc_peak_gpu_mem=True
+        )
     assert hook.max_mem == 0
     av_mem = cp.cuda.Device().mem_info[0]
     if av_mem < estimated_mem_peak:

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -57,7 +57,7 @@ def test_remove_stripe_fw_on_data(data, flats, darks):
     data_norm = dark_flat_field_correction(data, flats, darks, cutoff=10)
     data_norm = minus_log(data_norm)
 
-    data_after_stripe_removal = remove_stripe_fw(cp.copy(data_norm), level=7).get()
+    data_after_stripe_removal = remove_stripe_fw(cp.copy(data_norm), wname='sym16', sigma=1, level=7).get()
 
     assert_allclose(np.mean(data_after_stripe_removal), 0.279236, rtol=1e-05)
     assert_allclose(

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -57,7 +57,9 @@ def test_remove_stripe_fw_on_data(data, flats, darks):
     data_norm = dark_flat_field_correction(data, flats, darks, cutoff=10)
     data_norm = minus_log(data_norm)
 
-    data_after_stripe_removal = remove_stripe_fw(cp.copy(data_norm), wname='sym16', sigma=1, level=7).get()
+    data_after_stripe_removal = remove_stripe_fw(
+        cp.copy(data_norm), wname="sym16", sigma=1, level=7
+    ).get()
 
     assert_allclose(np.mean(data_after_stripe_removal), 0.279236, rtol=1e-05)
     assert_allclose(

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -87,14 +87,14 @@ def ensure_clean_memory():
 
 @pytest.mark.parametrize("wname", ["haar", "db4", "sym5", "sym16", "bior4.4"])
 @pytest.mark.parametrize("slices", [55, 80])
-@pytest.mark.parametrize("level", [1, 3, 7, 11])
+@pytest.mark.parametrize("level", [None, 1, 3, 7, 11])
 @pytest.mark.parametrize("dim_x", [128, 140])
 def test_remove_stripe_fw_calc_mem(slices, level, dim_x, wname, ensure_clean_memory):
     dim_y = 159
     data = cp.random.random_sample((slices, dim_x, dim_y), dtype=np.float32)
     hook = MaxMemoryHook()
     with hook:
-        remove_stripe_fw(cp.copy(data), level=level)
+        remove_stripe_fw(cp.copy(data), wname=wname, level=level)
     actual_mem_peak = hook.max_mem
 
     hook = MaxMemoryHook()

--- a/tests/test_prep/test_stripe.py
+++ b/tests/test_prep/test_stripe.py
@@ -102,7 +102,6 @@ def test_remove_stripe_fw_calc_mem(slices, level, dim_x, wname, ensure_clean_mem
         estimated_mem_peak = remove_stripe_fw(
             data.shape, level=level, wname=wname, calc_peak_gpu_mem=True
         )
-    assert hook.max_mem == 0
 
     assert actual_mem_peak * 0.99 <= estimated_mem_peak
     assert estimated_mem_peak <= actual_mem_peak * 1.3
@@ -122,7 +121,6 @@ def test_remove_stripe_fw_calc_mem_big(wname, slices, level, ensure_clean_memory
         estimated_mem_peak = remove_stripe_fw(
             data_shape, wname=wname, level=level, calc_peak_gpu_mem=True
         )
-    assert hook.max_mem == 0
     av_mem = cp.cuda.Device().mem_info[0]
     if av_mem < estimated_mem_peak:
         pytest.skip("Not enough GPU memory to run this test")


### PR DESCRIPTION
- Copied `remove_stripe_fw` implementation from https://gitlab.esrf.fr/tomotools/nabu/-/blob/master/nabu/thirdparty/tomocupy_remove_stripe.py#L311
  - Updated the original implementation so that trivial computations are not offloaded to the GPU
  - Note, that the implementation uses the PyWavelets dependency, which was already part of the httomo dependency chain, so this implementation keeps using it
- Added simple regression test to check that the result of the algorithm does not change
- Added simple regression test in zenodo-tests
- Implemented inline device memory peak calculation, which can be run by a bool flag passed to `remove_stripe_fw`
  - The memory peak calculation does not perform the stripe removal and does not use the GPU at all
  - The inline implementation's advantage is that the memory estimation path can reuse the same computed values that the regular path would use. Otherwise it would be difficult to estimate the memory peak of an iterative algorithm like this
  - A unit test is added for the calculator, that proves that it is accurate with a margin of +30/- 1%