### PR TITLE
Paganin filter: `padding_method` options

### DIFF
--- a/httomolibgpu/cupywrapper.py
+++ b/httomolibgpu/cupywrapper.py
@@ -2,6 +2,7 @@ cupy_run = False
 try:
     import cupy as cp
     import nvtx
+    from cupyx.scipy.fft import next_fast_len
 
     try:
         cp.cuda.Device(0).compute_capability
@@ -15,5 +16,6 @@ except ImportError as e:
     )
     from unittest.mock import Mock
     import numpy as cp
+    from scipy.fft import next_fast_len
 
     nvtx = Mock()

--- a/httomolibgpu/prep/phase.py
+++ b/httomolibgpu/prep/phase.py
@@ -60,7 +60,7 @@ def paganin_filter(
     calculate_padding_value_method: Literal[
         "next_power_of_2", "next_fast_length", "use_pad_x_y"
     ] = "next_power_of_2",
-    pad_x_y: Optional[Tuple[int, int]] = None,
+    pad_x_y: Optional[list] = None,
     calc_peak_gpu_mem: bool = False,
 ) -> cp.ndarray:
     """
@@ -81,7 +81,7 @@ def paganin_filter(
         The ratio of delta/beta, where delta is the phase shift and real part of the complex material refractive index and beta is the absorption.
     calculate_padding_value_method: str
         Method to calculate the padded size of the input data. Accepted values are 'next_power_of_2', 'next_fast_length' and 'use_pad_x_y`.
-    pad_x_y (int, int) | None:
+    pad_x_y list | None:
         Padding values in pixels horizontally and vertically. Must be None, unless `calculate_padding_value_method` is 'use_pad_x_y'.
     calc_peak_gpu_mem: bool
         Parameter to support memory estimation in HTTomo. Irrelevant to the method itself and can be ignored by user.
@@ -233,7 +233,7 @@ def _calculate_pad_size(
     calculate_padding_value_method: Literal[
         "next_power_of_2", "next_fast_length", "use_pad_x_y"
     ],
-    pad_x_y: Optional[Tuple[int, int]],
+    pad_x_y: Optional[list],
 ) -> list:
     """Calculating the padding size
 
@@ -252,10 +252,18 @@ def _calculate_pad_size(
         raise ValueError(
             'calculate_padding_value_method must be "use_pad_x_y" when pad_x_y is specified'
         )
-    elif calculate_padding_value_method == "use_pad_x_y" and pad_x_y is None:
-        raise ValueError(
-            'pad_x_y must be provided when calculate_padding_value_method is "use_pad_x_y"'
-        )
+    elif calculate_padding_value_method == "use_pad_x_y":
+        if pad_x_y is None:
+            raise ValueError(
+                'pad_x_y must be provided when calculate_padding_value_method is "use_pad_x_y"'
+            )
+        elif (
+            not isinstance(pad_x_y, list)
+            or len(pad_x_y) != 2
+            or not isinstance(pad_x_y[0], int)
+            or not isinstance(pad_x_y[1], int)
+        ):
+            raise ValueError("pad_x_y must be a list of two integers")
 
     if calculate_padding_value_method == "next_power_of_2":
         calculate_padded_dim = lambda _, size: _shift_bit_length(size + 1)
@@ -292,7 +300,7 @@ def _pad_projections(
     calculate_padding_value_method: Literal[
         "next_power_of_2", "next_fast_length", "use_pad_x_y"
     ],
-    pad_x_y: Optional[Tuple[int, int]],
+    pad_x_y: Optional[list],
     mem_stack: Optional[_DeviceMemStack],
 ) -> Tuple[cp.ndarray, Tuple[int, int]]:
     """
@@ -305,7 +313,7 @@ def _pad_projections(
         3d projection data
     calculate_padding_value_method: str
         Method to calculate the padded size of the input data. Accepted values are 'next_power_of_2', 'next_fast_length' and 'use_pad_x_y`.
-    pad_x_y (int, int) | None:
+    pad_x_y: list | None:
         Padding values in pixels horizontally and vertically. Must be None, unless `calculate_padding_value_method` is 'use_pad_x_y'.
 
 

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -51,6 +51,34 @@ def test_paganin_filter_dist3(data):
     assert_allclose(np.sum(filtered_data), -24870786.0, rtol=1e-6)
 
 
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ("next_power_of_2", None, -6.725061, -6.367116),
+        ("next_fast_length", None, -6.677313, -6.096187),
+        ("use_pad_x_y", (0, 0), -6.677313, -6.096187),
+        ("use_pad_x_y", (80, 80), -6.73193, -6.405338),
+        ("use_pad_x_y", (45, 75), -6.726483, -6.37466),
+    ],
+)
+def test_paganin_filter_padding_options(data, test_case):
+    # --- testing the Paganin filter on tomo_standard ---#
+    padding_method, pad_x_y, test_mean, test_max = test_case
+    filtered_data = paganin_filter(
+        data,
+        calculate_padding_value_method=padding_method,
+        pad_x_y=pad_x_y,
+    ).get()
+
+    assert filtered_data.ndim == 3
+    assert_allclose(np.mean(filtered_data), test_mean, rtol=eps)
+    assert_allclose(np.max(filtered_data), test_max, rtol=eps)
+
+    #: make sure the output is float32
+    assert filtered_data.dtype == np.float32
+    assert filtered_data.flags.c_contiguous
+
+
 @pytest.mark.perf
 def test_paganin_filter_performance(ensure_clean_memory):
     # Note: low/high and size values taken from sample2_medium.yaml real run
@@ -87,32 +115,65 @@ def test_paganin_filter_performance(ensure_clean_memory):
 
 @pytest.mark.parametrize("slices", [3, 7, 32, 61, 109, 120, 150])
 @pytest.mark.parametrize("dim_x", [128, 140])
-def test_paganin_filter_calc_mem(slices, dim_x, ensure_clean_memory):
+@pytest.mark.parametrize(
+    "padding",
+    [("next_power_of_2", None), ("next_fast_length", None), ("use_pad_x_y", (45, 45))],
+)
+def test_paganin_filter_calc_mem(slices, dim_x, padding, ensure_clean_memory):
     dim_y = 159
+    padding_method, pad_x_y = padding
+
     data = cp.random.random_sample((slices, dim_x, dim_y), dtype=np.float32)
     hook = MaxMemoryHook()
     with hook:
-        paganin_filter(cp.copy(data))
+        paganin_filter(
+            cp.copy(data),
+            calculate_padding_value_method=padding_method,
+            pad_x_y=pad_x_y,
+        )
     actual_mem_peak = hook.max_mem
 
     try:
-        estimated_mem_peak = paganin_filter(data.shape, calc_peak_gpu_mem=True)
+        estimated_mem_peak = paganin_filter(
+            data.shape,
+            calculate_padding_value_method=padding_method,
+            pad_x_y=pad_x_y,
+            calc_peak_gpu_mem=True,
+        )
     except cp.cuda.memory.OutOfMemoryError:
         pytest.skip("Not enough GPU memory to estimate memory peak")
 
-    assert actual_mem_peak * 0.99 <= estimated_mem_peak
-    assert estimated_mem_peak <= actual_mem_peak * 1.01
+    assert actual_mem_peak == estimated_mem_peak
 
 
 @pytest.mark.parametrize("slices", [38, 177, 268, 320, 490, 607, 803, 859, 902, 951])
 @pytest.mark.parametrize("dims", [(900, 1280), (1801, 1540), (1801, 2560)])
-def test_paganin_filter_calc_mem_big(slices, dims, ensure_clean_memory):
+@pytest.mark.parametrize(
+    "padding",
+    [
+        ("next_power_of_2", None),
+        ("next_fast_length", None),
+        ("use_pad_x_y", (145, 122)),
+    ],
+)
+def test_paganin_filter_calc_mem_big(slices, dims, padding, ensure_clean_memory):
     dim_y, dim_x = dims
     data_shape = (slices, dim_x, dim_y)
+    padding_method, pad_x_y = padding
     try:
-        estimated_mem_peak = paganin_filter(data_shape, calc_peak_gpu_mem=True)
+        estimated_mem_peak = paganin_filter(
+            data_shape,
+            calculate_padding_value_method=padding_method,
+            pad_x_y=pad_x_y,
+            calc_peak_gpu_mem=True,
+        )
     except cp.cuda.memory.OutOfMemoryError:
         pytest.skip("Not enough GPU memory to estimate memory peak")
+    except cp.cuda.cufft.CuFFTError as cufft_error:
+        if cufft_error.result == 8:  # CUFFT_INVALID_SIZE
+            pytest.skip("Not usable FFT size")
+        else:
+            raise
     av_mem = cp.cuda.Device().mem_info[0]
     if av_mem < estimated_mem_peak:
         pytest.skip("Not enough GPU memory to run this test")
@@ -120,8 +181,11 @@ def test_paganin_filter_calc_mem_big(slices, dims, ensure_clean_memory):
     hook = MaxMemoryHook()
     with hook:
         data = cp.random.random_sample(data_shape, dtype=np.float32)
-        paganin_filter(data)
+        paganin_filter(
+            data,
+            calculate_padding_value_method=padding_method,
+            pad_x_y=pad_x_y,
+        )
     actual_mem_peak = hook.max_mem
 
-    assert actual_mem_peak * 0.99 <= estimated_mem_peak
-    assert estimated_mem_peak <= actual_mem_peak * 1.01
+    assert actual_mem_peak == estimated_mem_peak

--- a/tests/test_prep/test_phase.py
+++ b/tests/test_prep/test_phase.py
@@ -21,6 +21,29 @@ def test_paganin_filter_1D_raises(ensure_clean_memory):
     _data = None  #: free up GPU memory
 
 
+@pytest.mark.parametrize(
+    "padding",
+    [
+        ("something", None),
+        ("something", [122, 133]),
+        ("next_power_of_2", [0, 0]),
+        ("next_fast_length", [20, 20]),
+        ("use_pad_x_y", [20, "20"]),
+        ("use_pad_x_y", [10, 20, 30]),
+        ("use_pad_x_y", [20, 20, 30]),
+        ("use_pad_x_y", (20, 20)),
+        ("use_pad_x_y", None),
+    ],
+)
+def test_paganin_filter_invalid_padding_raises(padding, ensure_clean_memory):
+    _data = cp.ones(10)
+    padding_method, pad_x_y = padding
+    with pytest.raises(ValueError):
+        paganin_filter(
+            _data, calculate_padding_value_method=padding_method, pad_x_y=pad_x_y
+        )
+
+
 def test_paganin_filter(data):
     # --- testing the Paganin filter on tomo_standard ---#
     filtered_data = paganin_filter(data).get()
@@ -56,9 +79,9 @@ def test_paganin_filter_dist3(data):
     [
         ("next_power_of_2", None, -6.725061, -6.367116),
         ("next_fast_length", None, -6.677313, -6.096187),
-        ("use_pad_x_y", (0, 0), -6.677313, -6.096187),
-        ("use_pad_x_y", (80, 80), -6.73193, -6.405338),
-        ("use_pad_x_y", (45, 75), -6.726483, -6.37466),
+        ("use_pad_x_y", [0, 0], -6.677313, -6.096187),
+        ("use_pad_x_y", [80, 80], -6.73193, -6.405338),
+        ("use_pad_x_y", [45, 75], -6.726483, -6.37466),
     ],
 )
 def test_paganin_filter_padding_options(data, test_case):
@@ -117,7 +140,7 @@ def test_paganin_filter_performance(ensure_clean_memory):
 @pytest.mark.parametrize("dim_x", [128, 140])
 @pytest.mark.parametrize(
     "padding",
-    [("next_power_of_2", None), ("next_fast_length", None), ("use_pad_x_y", (45, 45))],
+    [("next_power_of_2", None), ("next_fast_length", None), ("use_pad_x_y", [45, 45])],
 )
 def test_paganin_filter_calc_mem(slices, dim_x, padding, ensure_clean_memory):
     dim_y = 159
@@ -153,7 +176,7 @@ def test_paganin_filter_calc_mem(slices, dim_x, padding, ensure_clean_memory):
     [
         ("next_power_of_2", None),
         ("next_fast_length", None),
-        ("use_pad_x_y", (145, 122)),
+        ("use_pad_x_y", [145, 122]),
     ],
 )
 def test_paganin_filter_calc_mem_big(slices, dims, padding, ensure_clean_memory):

--- a/zenodo-tests/test_prep/test_phase.py
+++ b/zenodo-tests/test_prep/test_phase.py
@@ -13,7 +13,7 @@ from conftest import force_clean_gpu_memory
     [
         ("next_power_of_2", None, -6.2188172, -10.92260456),
         ("next_fast_length", None, -6.867182, -10.92272),
-        ("use_pad_x_y", (80, 80), -6.32930, -10.92270),
+        ("use_pad_x_y", [80, 80], -6.32930, -10.92270),
     ],
 )
 def test_paganin_filter_i12_dataset3(i12_dataset3, test_case, ensure_clean_memory):

--- a/zenodo-tests/test_prep/test_phase.py
+++ b/zenodo-tests/test_prep/test_phase.py
@@ -8,7 +8,16 @@ from conftest import force_clean_gpu_memory
 
 # ----------------------------------------------------------#
 # appplying paganin filter to i12_dataset3
-def test_paganin_filter_i12_dataset3(i12_dataset3, ensure_clean_memory):
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        ("next_power_of_2", None, -6.2188172, -10.92260456),
+        ("next_fast_length", None, -6.867182, -10.92272),
+        ("use_pad_x_y", (80, 80), -6.32930, -10.92270),
+    ],
+)
+def test_paganin_filter_i12_dataset3(i12_dataset3, test_case, ensure_clean_memory):
+    padding_method, pad_x_y, test_max, test_min = test_case
     inputdata = cp.empty((3, 2050, 2560))
     inputdata[0, :, :] = i12_dataset3[0]
     inputdata[1, :, :] = i12_dataset3[1]
@@ -17,7 +26,9 @@ def test_paganin_filter_i12_dataset3(i12_dataset3, ensure_clean_memory):
 
     ensure_clean_memory
 
-    filtered_paganin = paganin_filter(inputdata)
+    filtered_paganin = paganin_filter(
+        inputdata, calculate_padding_value_method=padding_method, pad_x_y=pad_x_y
+    )
 
-    assert pytest.approx(np.max(cp.asnumpy(filtered_paganin)), rel=1e-3) == -6.2188172
-    assert pytest.approx(np.min(cp.asnumpy(filtered_paganin)), rel=1e-3) == -10.92260456
+    assert pytest.approx(np.max(cp.asnumpy(filtered_paganin)), rel=1e-3) == test_max
+    assert pytest.approx(np.min(cp.asnumpy(filtered_paganin)), rel=1e-3) == test_min


### PR DESCRIPTION
Added `padding_method` parameter to `paganin_filter`. Options:
- `next_power_of_2` (default, original method): Pads data to the size that is the next power of 2
- `next_fast_length`: Pads data to the next size that is fast for FFT. This can be zero padding. Uses less memory than `next_power_of_2`
- Integer: specifies padding extent in pixels.

Updated tests and zenodo tests.

Fixes: [Paganin filter padding options](https://github.com/RadWay-Tech-Services/issue/issues/63)